### PR TITLE
Update Oracle connection URLs

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -38,7 +38,7 @@ wait_for_database() {
     
     while [ $attempt -le $max_attempts ]; do
         if java -cp app.jar org.springframework.boot.loader.JarLauncher \
-           --spring.datasource.url="jdbc:oracle:thin:@${ORACLE_DB_HOST}:${ORACLE_DB_PORT:-1521}:${ORACLE_DB_SERVICE:-ORCL}" \
+           --spring.datasource.url="jdbc:oracle:thin:@//${ORACLE_DB_HOST:${default_host}}:${ORACLE_DB_PORT:-1521}/${ORACLE_DB_SERVICE:-ORCL}" \
            --spring.datasource.username="${ORACLE_DB_USER}" \
            --spring.datasource.password="${ORACLE_DB_PASSWORD}" \
            --spring.datasource.driver-class-name=oracle.jdbc.OracleDriver \

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.port=8080
 server.servlet.context-path=/
 
 # Configuração do banco de dados Oracle (OCI)
-spring.datasource.url=jdbc:oracle:thin:@${ORACLE_DB_HOST:localhost}:${ORACLE_DB_PORT:1521}:${ORACLE_DB_SERVICE:ORCL}
+spring.datasource.url=jdbc:oracle:thin:@//${ORACLE_DB_HOST:${default_host}}:${ORACLE_DB_PORT:1521}/${ORACLE_DB_SERVICE:ORCL}
 spring.datasource.username=${ORACLE_DB_USER:agentes_user}
 spring.datasource.password=${ORACLE_DB_PASSWORD:agentes_pass}
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver

--- a/backend/target/classes/application.properties
+++ b/backend/target/classes/application.properties
@@ -6,7 +6,7 @@ server.port=8080
 server.servlet.context-path=/
 
 # Configuração do banco de dados Oracle (OCI)
-spring.datasource.url=jdbc:oracle:thin:@${ORACLE_DB_HOST:localhost}:${ORACLE_DB_PORT:1521}:${ORACLE_DB_SERVICE:ORCL}
+spring.datasource.url=jdbc:oracle:thin:@//${ORACLE_DB_HOST:${default_host}}:${ORACLE_DB_PORT:1521}/${ORACLE_DB_SERVICE:ORCL}
 spring.datasource.username=${ORACLE_DB_USER:agentes_user}
 spring.datasource.password=${ORACLE_DB_PASSWORD:agentes_pass}
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: agentes-backend
     environment:
       - SPRING_PROFILES_ACTIVE=docker
-      - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@oracle-db:1521:XE
+      - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@//oracle-db:1521/XE
       - SPRING_DATASOURCE_USERNAME=agentes_user
       - SPRING_DATASOURCE_PASSWORD=agentes_pass
       - GOVBR_CLIENT_ID=${GOVBR_CLIENT_ID}

--- a/k8s/oke-deployment.yaml
+++ b/k8s/oke-deployment.yaml
@@ -123,16 +123,18 @@ spec:
             configMapKeyRef:
               name: agentes-config
               key: ORACLE_DB_PORT
-        - name: ORACLE_DB_SERVICE
-          valueFrom:
-            configMapKeyRef:
-              name: agentes-config
-              key: ORACLE_DB_SERVICE
-        - name: ORACLE_DB_SCHEMA
-          valueFrom:
-            configMapKeyRef:
-              name: agentes-config
-              key: ORACLE_DB_SCHEMA
+          - name: ORACLE_DB_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: agentes-config
+                key: ORACLE_DB_SERVICE
+          - name: SPRING_DATASOURCE_URL
+            value: "jdbc:oracle:thin:@//oracle-db.tjmg.local:1521/AGENTES_PDB"
+          - name: ORACLE_DB_SCHEMA
+            valueFrom:
+              configMapKeyRef:
+                name: agentes-config
+                key: ORACLE_DB_SCHEMA
         - name: APP_ENVIRONMENT
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## Summary
- fix datasource URL for property files
- update docker-compose with new URL format
- tweak entrypoint script connection string
- expose datasource URL via k8s deployment

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_6880e2611110833188fa7a78ab8151d0