### PR TITLE
Fix datasource URL to reference XEPDB1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: agentes-backend
     environment:
       - SPRING_PROFILES_ACTIVE=docker
-      - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@//oracle-db:1521/XE
+      - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@//oracle-db:1521/XEPDB1
       - SPRING_DATASOURCE_USERNAME=agentes_user
       - SPRING_DATASOURCE_PASSWORD=agentes_pass
       - GOVBR_CLIENT_ID=${GOVBR_CLIENT_ID}


### PR DESCRIPTION
## Summary
- point Spring datasource URL to `XEPDB1` service in `docker-compose.yml`

## Testing
- `npm test --prefix frontend/agentes-frontend` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6880e62a33b4833189e67a2ba91a4b96