### PR TITLE
Add env example and update quick-start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Example environment configuration for the Agentes Voluntários system
+# Oracle Database
+ORACLE_DB_HOST=oracle-db
+ORACLE_DB_PORT=1521
+ORACLE_DB_SERVICE=XE
+ORACLE_DB_USER=agentes_user
+ORACLE_DB_PASSWORD=agentes_pass
+ORACLE_DB_SCHEMA=agentes_user
+
+# gov.br OAuth2 credentials
+GOVBR_CLIENT_ID=seu-client-id
+GOVBR_CLIENT_SECRET=seu-client-secret
+GOVBR_REDIRECT_URI=http://localhost/auth/govbr/callback
+
+# Keycloak authentication
+KEYCLOAK_ISSUER_URI=http://localhost:8180/realms/agentes-voluntarios
+KEYCLOAK_JWK_SET_URI=http://localhost:8180/realms/agentes-voluntarios/protocol/openid-connect/certs
+
+# Application settings
+APP_BASE_URL=http://localhost
+APP_ENVIRONMENT=local
+
+# Oracle Cloud Infrastructure (optional)
+OCI_REGION=sa-saopaulo-1
+OCI_BUCKET_NAME=agentes-anexos

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ cd sistema-agentes-voluntarios
 
 # Configurar variáveis de ambiente
 cp .env.example .env
+# Edite o arquivo `.env` e ajuste ORACLE_DB_HOST, ORACLE_DB_SERVICE e credenciais
 nano .env
 
 # Executar deploy


### PR DESCRIPTION
## Summary
- add `.env.example` with Oracle DB and gov.br variables
- reference `.env.example` in the quick-start instructions

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6880e75f3d0083319bd0d436c92955f3