### PR TITLE
Use XEPDB1 PDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 # Oracle Database
 ORACLE_DB_HOST=oracle-db
 ORACLE_DB_PORT=1521
-ORACLE_DB_SERVICE=XE
+# Nome do serviço/PDB utilizado pelo backend
+ORACLE_DB_SERVICE=XEPDB1
 ORACLE_DB_USER=agentes_user
 ORACLE_DB_PASSWORD=agentes_pass
 ORACLE_DB_SCHEMA=agentes_user

--- a/database/init/01-init-oracle.sql
+++ b/database/init/01-init-oracle.sql
@@ -2,7 +2,8 @@
 -- Sistema de Gestão de Agentes Voluntários v2.0
 -- Compatível com Oracle Cloud Infrastructure (OCI)
 
-ALTER SESSION SET CONTAINER = CDB$ROOT;
+-- Garantir que os objetos sejam criados no PDB XEPDB1
+ALTER SESSION SET CONTAINER = XEPDB1;
 SET PAGESIZE 0;
 SET FEEDBACK OFF;
 SET ECHO ON;


### PR DESCRIPTION
## Summary
- set PDB before creating tables in Oracle init script
- update example environment file to use the same service name

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ee8561208331a6df214013147b1a