### PR TITLE
Add auto infracao frontend module

### DIFF
--- a/frontend/agentes-frontend/src/app/app.routes.ts
+++ b/frontend/agentes-frontend/src/app/app.routes.ts
@@ -5,6 +5,9 @@ import { AgenteListaComponent } from './components/agente-lista/agente-lista.com
 import { PainelAgentesComponent } from './components/painel-agentes/painel-agentes.component';
 import { CredencialEmissaoComponent } from './components/credencial-emissao/credencial-emissao.component';
 import { ConsultaPublicaComponent } from './components/consulta-publica/consulta-publica.component';
+import { AutoInfracaoCadastroComponent } from './components/auto-infracao-cadastro/auto-infracao-cadastro.component';
+import { AutoInfracaoListaComponent } from './components/auto-infracao-lista/auto-infracao-lista.component';
+import { AutoInfracaoDetalheComponent } from './components/auto-infracao-detalhe/auto-infracao-detalhe.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/login', pathMatch: 'full' },
@@ -14,6 +17,9 @@ export const routes: Routes = [
   { path: 'agentes/cadastro', component: AgenteCadastroComponent },
   { path: 'credenciais', component: CredencialEmissaoComponent },
   { path: 'consulta-publica', component: ConsultaPublicaComponent },
+  { path: 'autos', component: AutoInfracaoListaComponent },
+  { path: 'autos/cadastro', component: AutoInfracaoCadastroComponent },
+  { path: 'autos/:id', component: AutoInfracaoDetalheComponent },
   { path: '**', redirectTo: '/login' }
 ];
 

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.html
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.html
@@ -1,0 +1,76 @@
+<div class="container-fluid py-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h5 class="mb-0">
+            <i class="fas fa-file-alt me-2"></i>
+            Novo Auto de Infração
+          </h5>
+          <button class="btn btn-outline-secondary" (click)="cancelar()">
+            <i class="fas fa-arrow-left me-2"></i>
+            Voltar
+          </button>
+        </div>
+        <div class="card-body">
+          <form [formGroup]="form" (ngSubmit)="salvar()" novalidate>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label class="form-label">Nome do Autuado</label>
+                <input class="form-control" formControlName="nomeAutuado">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">CPF/CNPJ</label>
+                <input class="form-control" formControlName="cpfCnpjAutuado">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Endereço</label>
+                <input class="form-control" formControlName="enderecoAutuado">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Contato</label>
+                <input class="form-control" formControlName="contatoAutuado">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Comarca</label>
+                <select class="form-select" formControlName="comarcaId">
+                  <option value="" disabled selected>Selecione</option>
+                  <option *ngFor="let c of comarcas" [value]="c.id">{{c.nomeComarca}}</option>
+                </select>
+              </div>
+              <div class="col-md-8">
+                <label class="form-label">Base Legal</label>
+                <input class="form-control" formControlName="baseLegal">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Data</label>
+                <input type="date" class="form-control" formControlName="dataInfracao">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Hora</label>
+                <input type="time" class="form-control" formControlName="horaInfracao">
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Local</label>
+                <input class="form-control" formControlName="localInfracao">
+              </div>
+              <div class="col-12">
+                <label class="form-label">Descrição da Conduta</label>
+                <textarea class="form-control" rows="3" formControlName="descricaoConduta"></textarea>
+              </div>
+              <div class="col-12">
+                <label class="form-label">Anexo</label>
+                <input type="file" class="form-control" (change)="onFileChange($event)">
+              </div>
+            </div>
+            <div class="mt-4 d-flex justify-content-end">
+              <button type="submit" class="btn btn-primary" [disabled]="loading">
+                Salvar
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.scss
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.scss
@@ -1,0 +1,1 @@
+/* Estilos básicos para o formulário */

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.ts
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-cadastro/auto-infracao-cadastro.component.ts
@@ -1,0 +1,76 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ApiService } from '../../services/api.service';
+import { AutoInfracao, Comarca } from '../../models/interfaces';
+
+@Component({
+  selector: 'app-auto-infracao-cadastro',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './auto-infracao-cadastro.component.html',
+  styleUrls: ['./auto-infracao-cadastro.component.scss']
+})
+export class AutoInfracaoCadastroComponent implements OnInit {
+  form: FormGroup;
+  comarcas: Comarca[] = [];
+  selectedFile: File | null = null;
+  loading = false;
+
+  constructor(private fb: FormBuilder, private api: ApiService, private router: Router) {
+    this.form = this.fb.group({
+      nomeAutuado: ['', Validators.required],
+      cpfCnpjAutuado: ['', Validators.required],
+      enderecoAutuado: ['', Validators.required],
+      contatoAutuado: ['', Validators.required],
+      comarcaId: ['', Validators.required],
+      baseLegal: ['', Validators.required],
+      dataInfracao: ['', Validators.required],
+      horaInfracao: ['', Validators.required],
+      localInfracao: ['', Validators.required],
+      descricaoConduta: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void {
+    this.api.listarComarcas().subscribe(cs => this.comarcas = cs);
+  }
+
+  onFileChange(event: any): void {
+    const file = event.target.files[0];
+    if (file) {
+      this.selectedFile = file;
+    }
+  }
+
+  salvar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const auto: AutoInfracao = {
+      ...this.form.value
+    } as AutoInfracao;
+
+    this.loading = true;
+    this.api.cadastrarAuto(auto).subscribe({
+      next: a => {
+        if (this.selectedFile) {
+          this.api.uploadAnexo(a.id!, this.selectedFile!).subscribe({
+            next: () => this.router.navigate(['/autos']),
+            error: () => this.loading = false
+          });
+        } else {
+          this.router.navigate(['/autos']);
+        }
+      },
+      error: () => this.loading = false
+    });
+  }
+
+  cancelar(): void {
+    this.router.navigate(['/autos']);
+  }
+}

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.html
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.html
@@ -1,0 +1,39 @@
+<div class="container-fluid py-4" *ngIf="auto">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h5 class="mb-0">
+            <i class="fas fa-file-alt me-2"></i>
+            Detalhe do Auto
+          </h5>
+          <a class="btn btn-outline-secondary" routerLink="/autos">
+            <i class="fas fa-arrow-left me-1"></i> Voltar
+          </a>
+        </div>
+        <div class="card-body">
+          <dl class="row">
+            <dt class="col-sm-3">Autuado</dt>
+            <dd class="col-sm-9">{{auto?.nomeAutuado}}</dd>
+            <dt class="col-sm-3">Status</dt>
+            <dd class="col-sm-9">{{auto?.status}}</dd>
+            <dt class="col-sm-3">Data</dt>
+            <dd class="col-sm-9">{{auto?.dataInfracao | date}}</dd>
+          </dl>
+          <h6>Anexos</h6>
+          <ul class="list-unstyled">
+            <li *ngFor="let a of anexos" class="mb-1">
+              {{a.nomeOriginal}}
+              <button class="btn btn-link btn-sm" (click)="download(a.id!)">Download</button>
+            </li>
+          </ul>
+          <div class="mt-3" *ngIf="auto.status !== 'CANCELADO'">
+            <label class="form-label">Justificativa Cancelamento</label>
+            <textarea class="form-control" [(ngModel)]="justificativa"></textarea>
+            <button class="btn btn-danger mt-2" (click)="cancelarAuto()">Cancelar Auto</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.scss
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.scss
@@ -1,0 +1,1 @@
+/* Estilos do detalhe do auto */

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.ts
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-detalhe/auto-infracao-detalhe.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../services/api.service';
+import { AutoInfracao, AnexoAutoInfracao } from '../../models/interfaces';
+
+@Component({
+  selector: 'app-auto-infracao-detalhe',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './auto-infracao-detalhe.component.html',
+  styleUrls: ['./auto-infracao-detalhe.component.scss']
+})
+export class AutoInfracaoDetalheComponent implements OnInit {
+  auto: AutoInfracao | null = null;
+  anexos: AnexoAutoInfracao[] = [];
+  justificativa = '';
+
+  constructor(private route: ActivatedRoute, private api: ApiService, private router: Router) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.api.buscarAutoPorId(id).subscribe(a => {
+        this.auto = a;
+        this.carregarAnexos();
+      });
+    }
+  }
+
+  carregarAnexos(): void {
+    if (!this.auto) return;
+    this.api.listarAnexos(this.auto.id!).subscribe(anx => this.anexos = anx);
+  }
+
+  download(anexoId: number): void {
+    this.api.downloadAnexo(anexoId).subscribe(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'anexo';
+      link.click();
+      window.URL.revokeObjectURL(url);
+    });
+  }
+
+  cancelarAuto(): void {
+    if (!this.auto) return;
+    this.api.cancelarAuto(this.auto.id!, this.justificativa).subscribe(() => this.router.navigate(['/autos']));
+  }
+}

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.html
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.html
@@ -1,0 +1,52 @@
+<div class="container-fluid py-4">
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h5 class="mb-0">
+            <i class="fas fa-list me-2"></i>
+            Autos de Infração
+          </h5>
+          <a class="btn btn-primary" routerLink="/autos/cadastro">
+            <i class="fas fa-plus me-1"></i> Novo
+          </a>
+        </div>
+        <div class="card-body">
+          <div class="row mb-3">
+            <div class="col-md-3">
+              <input type="text" class="form-control form-control-sm" placeholder="Autuado" [(ngModel)]="filtros.nomeAutuado" (input)="aplicarFiltros()">
+            </div>
+            <div class="col-md-3">
+              <select class="form-select form-select-sm" [(ngModel)]="filtros.status" (change)="aplicarFiltros()">
+                <option value="">Todos Status</option>
+                <option *ngFor="let s of ['RASCUNHO','REGISTRADO','CONCLUIDO','CANCELADO']" [value]="s">{{s}}</option>
+              </select>
+            </div>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-hover mb-0">
+              <thead>
+                <tr>
+                  <th>Autuado</th>
+                  <th>Data</th>
+                  <th>Status</th>
+                  <th>Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let auto of autos">
+                  <td>{{auto.nomeAutuado}}</td>
+                  <td>{{auto.dataInfracao | date:'shortDate'}}</td>
+                  <td>{{auto.status}}</td>
+                  <td>
+                    <a class="btn btn-sm btn-outline-primary" [routerLink]="['/autos', auto.id]">Ver</a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.scss
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.scss
@@ -1,0 +1,1 @@
+/* Estilos da tabela de autos */

--- a/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.ts
+++ b/frontend/agentes-frontend/src/app/components/auto-infracao-lista/auto-infracao-lista.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../services/api.service';
+import { AutoInfracao, PaginatedResponse, StatusAutoInfracao } from '../../models/interfaces';
+
+@Component({
+  selector: 'app-auto-infracao-lista',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './auto-infracao-lista.component.html',
+  styleUrls: ['./auto-infracao-lista.component.scss']
+})
+export class AutoInfracaoListaComponent implements OnInit {
+  autos: AutoInfracao[] = [];
+  page = 0;
+  totalPages = 0;
+  filtros: any = {};
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.api.listarAutos(this.page, 10, this.filtros).subscribe((resp: PaginatedResponse<AutoInfracao>) => {
+      this.autos = resp.content;
+      this.totalPages = resp.totalPages;
+    });
+  }
+
+  aplicarFiltros(): void {
+    this.page = 0;
+    this.carregar();
+  }
+}

--- a/frontend/agentes-frontend/src/app/components/header/header.component.html
+++ b/frontend/agentes-frontend/src/app/components/header/header.component.html
@@ -32,6 +32,12 @@
             Credenciais
           </a>
         </li>
+        <li class="nav-item" *ngIf="isLoggedIn">
+          <a class="nav-link" routerLink="/autos" routerLinkActive="active">
+            <i class="fas fa-file-alt me-1"></i>
+            Autos de Infração
+          </a>
+        </li>
         <li class="nav-item">
           <a class="nav-link" routerLink="/consulta-publica" routerLinkActive="active">
             <i class="fas fa-search me-1"></i>

--- a/frontend/agentes-frontend/src/app/models/interfaces.ts
+++ b/frontend/agentes-frontend/src/app/models/interfaces.ts
@@ -112,3 +112,57 @@ export interface PaginatedResponse<T> {
   number: number;
 }
 
+// ===== AUTOS DE INFRAÇÃO =====
+
+export enum StatusAutoInfracao {
+  RASCUNHO = 'RASCUNHO',
+  REGISTRADO = 'REGISTRADO',
+  CONCLUIDO = 'CONCLUIDO',
+  CANCELADO = 'CANCELADO'
+}
+
+export interface AnexoAutoInfracao {
+  id?: number;
+  autoInfracaoId: string;
+  nomeArquivo: string;
+  nomeOriginal: string;
+  tipoArquivo: string;
+  tamanhoArquivo: number;
+  caminhoArquivo: string;
+  descricao?: string;
+  dataUpload?: string;
+  usuarioUpload?: string;
+}
+
+export interface AutoInfracao {
+  id?: string;
+  nomeAutuado: string;
+  cpfCnpjAutuado: string;
+  enderecoAutuado: string;
+  contatoAutuado: string;
+  agenteId?: string;
+  nomeAgente?: string;
+  matriculaAgente?: string;
+  comarcaId: string;
+  baseLegal: string;
+  dataInfracao: string;
+  horaInfracao: string;
+  localInfracao: string;
+  descricaoConduta: string;
+  iniciaisCrianca?: string;
+  idadeCrianca?: number;
+  sexoCrianca?: string;
+  nomeTestemunha?: string;
+  cpfTestemunha?: string;
+  assinaturaAutuado?: boolean;
+  status?: StatusAutoInfracao;
+  dataCadastro?: string;
+  dataAtualizacao?: string;
+  usuarioCadastro?: string;
+  usuarioAtualizacao?: string;
+  dataCancelamento?: string;
+  usuarioCancelamento?: string;
+  justificativaCancelamento?: string;
+  anexos?: AnexoAutoInfracao[];
+}
+

--- a/frontend/agentes-frontend/src/app/services/api.service.ts
+++ b/frontend/agentes-frontend/src/app/services/api.service.ts
@@ -7,11 +7,13 @@ import {
   AgenteVoluntarioDTO, 
   Comarca, 
   AreaAtuacao, 
-  Credencial, 
+  Credencial,
   ConsultaPublica,
   LoginGovBr,
   Usuario,
-  PaginatedResponse
+  PaginatedResponse,
+  AutoInfracao,
+  AnexoAutoInfracao
 } from '../models/interfaces';
 
 @Injectable({
@@ -191,6 +193,89 @@ export class ApiService {
 
   cadastrarAreaAtuacao(area: AreaAtuacao): Observable<AreaAtuacao> {
     return this.http.post<AreaAtuacao>(`${this.baseUrl}/api/areas-atuacao`, area, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  // ===== AUTOS DE INFRAÇÃO =====
+
+  listarAutos(page: number = 0, size: number = 10, filtros?: any): Observable<PaginatedResponse<AutoInfracao>> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', size.toString());
+
+    if (filtros) {
+      Object.keys(filtros).forEach(key => {
+        if (filtros[key] !== undefined && filtros[key] !== '') {
+          params = params.set(key, filtros[key]);
+        }
+      });
+    }
+
+    return this.http.get<PaginatedResponse<AutoInfracao>>(`${this.baseUrl}/api/autos`, {
+      headers: this.getAuthHeaders(),
+      params
+    });
+  }
+
+  buscarAutoPorId(id: string): Observable<AutoInfracao> {
+    return this.http.get<AutoInfracao>(`${this.baseUrl}/api/autos/${id}`, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  cadastrarAuto(auto: AutoInfracao): Observable<AutoInfracao> {
+    return this.http.post<AutoInfracao>(`${this.baseUrl}/api/autos`, auto, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  atualizarAuto(id: string, auto: AutoInfracao): Observable<AutoInfracao> {
+    return this.http.put<AutoInfracao>(`${this.baseUrl}/api/autos/${id}`, auto, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  cancelarAuto(id: string, justificativa: string): Observable<AutoInfracao> {
+    const body = { justificativa };
+    return this.http.patch<AutoInfracao>(`${this.baseUrl}/api/autos/${id}/cancelar`, body, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  excluirAuto(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/api/autos/${id}`, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  listarAnexos(autoId: string): Observable<AnexoAutoInfracao[]> {
+    return this.http.get<AnexoAutoInfracao[]>(`${this.baseUrl}/api/autos/${autoId}/anexos`, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  uploadAnexo(autoId: string, arquivo: File, descricao?: string): Observable<AnexoAutoInfracao> {
+    const formData = new FormData();
+    formData.append('arquivo', arquivo);
+    if (descricao) {
+      formData.append('descricao', descricao);
+    }
+
+    return this.http.post<AnexoAutoInfracao>(`${this.baseUrl}/api/autos/${autoId}/anexos`, formData, {
+      headers: this.getAuthHeaders().delete('Content-Type')
+    });
+  }
+
+  downloadAnexo(anexoId: number): Observable<Blob> {
+    return this.http.get(`${this.baseUrl}/api/anexos/${anexoId}/download`, {
+      headers: this.getAuthHeaders(),
+      responseType: 'blob'
+    });
+  }
+
+  excluirAnexo(anexoId: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/api/anexos/${anexoId}`, {
       headers: this.getAuthHeaders()
     });
   }


### PR DESCRIPTION
## Summary
- define AutoInfracao, StatusAutoInfracao and AnexoAutoInfracao interfaces
- expand ApiService with endpoints for autos and anexos
- add components for creating, viewing and listing autos
- register new routes and update navigation menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888b869606c833194ce9cc9aeff674a