### PR TITLE
refactor: load API base URL from environment

### DIFF
--- a/frontend/agentes-frontend/src/app/services/api.service.ts
+++ b/frontend/agentes-frontend/src/app/services/api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { map, catchError } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 import { AuthService } from './auth.service';
 import { 
   AgenteVoluntario, 
@@ -21,7 +21,7 @@ import {
   providedIn: 'root'
 })
 export class ApiService {
-  private baseUrl = 'http://localhost:8080';
+  private baseUrl = environment.apiUrl;
 
   constructor(private http: HttpClient, private authService: AuthService) {}
 

--- a/frontend/agentes-frontend/src/environments/environment.ts
+++ b/frontend/agentes-frontend/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: (import.meta as any).env.NG_APP_API_URL || 'http://localhost:8080'
+};


### PR DESCRIPTION
## Summary
- replace hardcoded API base URL with value from the environment
- drop unused RxJS operator imports

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bf4edd688331a360c77c71985ff2