### PR TITLE
feat: add standalone button component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.html
@@ -1,1 +1,14 @@
-<p>button works!</p>
+<button
+  type="button"
+  [ngClass]="[type, size]"
+  [disabled]="disabled"
+  (click)="onClick($event)"
+>
+  <ng-container *ngIf="iconLeft">
+    <i [ngClass]="iconLeft"></i>
+  </ng-container>
+  <span *ngIf="label" class="label">{{ label }}</span>
+  <ng-container *ngIf="iconRight">
+    <i [ngClass]="iconRight"></i>
+  </ng-container>
+</button>

--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.scss
@@ -1,0 +1,113 @@
+@import "../../../general/colors/colors.scss";
+
+button {
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+  width: fit-content;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+/* Sizes */
+button.sm {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+}
+
+button.md {
+  font-size: 0.875rem;
+  padding: 0.5rem 1rem;
+}
+
+button.lg {
+  font-size: 1rem;
+  padding: 0.75rem 1.25rem;
+}
+
+/* Types */
+button.primary {
+  background: $red-800;
+  color: #fff;
+}
+
+button.primary:hover:not(:disabled) {
+  background: $red-700;
+}
+
+button.primary:active:not(:disabled) {
+  background: $red-900;
+}
+
+button.primary:disabled {
+  background: $neutral-300;
+  color: #fff;
+}
+
+button.secondary {
+  background: $neutral-700;
+  color: #fff;
+}
+
+button.secondary:hover:not(:disabled) {
+  background: $neutral-600;
+}
+
+button.secondary:active:not(:disabled) {
+  background: $neutral-800;
+}
+
+button.secondary:disabled {
+  background: $neutral-300;
+  color: #fff;
+}
+
+button.danger {
+  background: $red-600;
+  color: #fff;
+}
+
+button.danger:hover:not(:disabled) {
+  background: $red-500;
+}
+
+button.danger:active:not(:disabled) {
+  background: $red-700;
+}
+
+button.danger:disabled {
+  background: $neutral-300;
+  color: #fff;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid $red-800;
+  color: $red-800;
+}
+
+button.ghost:hover:not(:disabled) {
+  background: $red-50;
+}
+
+button.ghost:active:not(:disabled) {
+  background: $red-100;
+}
+
+button.ghost:disabled {
+  border-color: $neutral-300;
+  color: $neutral-300;
+}
+
+@media (max-width: 480px) {
+  button {
+    width: 100%;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.spec.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.spec.ts
@@ -20,4 +20,11 @@ describe('ButtonComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should emit clicked event when button is pressed', () => {
+    spyOn(component.clicked, 'emit');
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    expect(component.clicked.emit).toHaveBeenCalled();
+  });
 });

--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.ts
@@ -1,11 +1,28 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'app-button',
-  imports: [],
+  standalone: true,
+  imports: [NgClass],
   templateUrl: './button.component.html',
-  styleUrl: './button.component.scss'
+  styleUrls: ['./button.component.scss']
 })
 export class ButtonComponent {
+  @Input() label: string = '';
+  @Input() type: 'primary' | 'secondary' | 'danger' | 'ghost' = 'primary';
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() disabled: boolean = false;
+  @Input() iconLeft?: string;
+  @Input() iconRight?: string;
 
+  @Output() clicked = new EventEmitter<Event>();
+
+  onClick(event: Event): void {
+    if (this.disabled) {
+      event.preventDefault();
+      return;
+    }
+    this.clicked.emit(event);
+  }
 }


### PR DESCRIPTION
## Summary
- add configurable `ButtonComponent` with style variants, sizes, icons and click event
- include responsive SCSS styling and color states
- test that button emits click event

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c6fd962c8331a49c49ec17b05bad