### PR TITLE
feat(button): add type and routerLink inputs

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.html
@@ -1,5 +1,6 @@
 <button
-  type="button"
+  [attr.type]="buttonType"
+  [routerLink]="routerLink"
   [ngClass]="[type, size]"
   [disabled]="disabled"
   (click)="onClick($event)"

--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.spec.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RouterLink } from '@angular/router';
+import { By } from '@angular/platform-browser';
 
 import { ButtonComponent } from './button.component';
 
@@ -8,7 +11,7 @@ describe('ButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ButtonComponent]
+      imports: [ButtonComponent, RouterTestingModule]
     })
     .compileComponents();
 
@@ -26,5 +29,20 @@ describe('ButtonComponent', () => {
     const button = fixture.nativeElement.querySelector('button');
     button.click();
     expect(component.clicked.emit).toHaveBeenCalled();
+  });
+
+  it('should set button type attribute based on buttonType input', () => {
+    component.buttonType = 'submit';
+    fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('type')).toBe('submit');
+  });
+
+  it('should bind routerLink to the button', () => {
+    component.routerLink = '/home';
+    fixture.detectChanges();
+    const debugEl = fixture.debugElement.query(By.directive(RouterLink));
+    const routerLinkInstance = debugEl.injector.get(RouterLink);
+    expect(routerLinkInstance.routerLink).toBe('/home');
   });
 });

--- a/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/buttons/button/button.component.ts
@@ -1,10 +1,11 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgClass } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-button',
   standalone: true,
-  imports: [NgClass],
+  imports: [NgClass, RouterLink],
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss']
 })
@@ -15,6 +16,8 @@ export class ButtonComponent {
   @Input() disabled: boolean = false;
   @Input() iconLeft?: string;
   @Input() iconRight?: string;
+  @Input() buttonType: 'button' | 'submit' | 'reset' = 'button';
+  @Input() routerLink?: string | any[];
 
   @Output() clicked = new EventEmitter<Event>();
 


### PR DESCRIPTION
## Summary
- add `buttonType` and `routerLink` inputs to the shared button component
- bind `buttonType` and `routerLink` in the button template
- cover new inputs in button component unit tests

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `CHROME_BIN=chromium-browser npm test -- --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc8e378083319d8cf09b8a91e94f