### PR TITLE
feat(login): substituir botoes pelo ButtonComponent

### DIFF
--- a/frontend/agentes-frontend/src/app/components/login/login.component.html
+++ b/frontend/agentes-frontend/src/app/components/login/login.component.html
@@ -20,10 +20,13 @@
                   <i class="fas fa-user-shield fa-3x text-primary mb-3"></i>
                   <h5>Acesso Administrativo</h5>
                   <p class="text-muted">Para usuários da Corregedoria e COFIJ</p>
-                  <button class="btn btn-primary w-100" (click)="loginKeycloak()">
-                    <i class="fas fa-key me-2"></i>
-                    Entrar com Keycloak
-                  </button>
+                  <app-button
+                    class="w-100"
+                    label="Entrar com Keycloak"
+                    type="primary"
+                    iconLeft="fas fa-key"
+                    (clicked)="loginKeycloak()"
+                  ></app-button>
                 </div>
               </div>
             </div>
@@ -35,14 +38,15 @@
                   <i class="fas fa-id-card fa-3x text-success mb-3"></i>
                   <h5>Agente Voluntário</h5>
                   <p class="text-muted">Para agentes cadastrados no sistema</p>
-                  <button class="btn btn-success w-100" (click)="loginGovBr()" [disabled]="loading">
-                    <i class="fas fa-government me-2"></i>
-                    <span *ngIf="!loading">Entrar com gov.br</span>
-                    <span *ngIf="loading">
-                      <i class="fas fa-spinner fa-spin me-2"></i>
-                      Carregando...
-                    </span>
-                  </button>
+                  <app-button
+                    class="w-100"
+                    label="Entrar com gov.br"
+                    type="secondary"
+                    iconLeft="fas fa-government"
+                    size="md"
+                    [disabled]="loading"
+                    (clicked)="loginGovBr()"
+                  ></app-button>
                 </div>
               </div>
             </div>

--- a/frontend/agentes-frontend/src/app/components/login/login.component.ts
+++ b/frontend/agentes-frontend/src/app/components/login/login.component.ts
@@ -4,11 +4,12 @@ import { ApiService } from '../../services/api.service';
 import { AuthService } from '../../services/auth.service';
 import { Usuario } from '../../models/interfaces';
 import { CommonModule } from '@angular/common';
+import { ButtonComponent } from '../../shared/components/buttons/button/button.component';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ButtonComponent],
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })


### PR DESCRIPTION
## Summary
- importa e registra ButtonComponent no LoginComponent
- substitui botoes HTML por `<app-button>` com variacoes primarias e secundarias

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless could not start; chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ce411cb083319ba4d0db5b34fbad