### PR TITLE
feat(frontend): add button component to header

### DIFF
--- a/frontend/agentes-frontend/src/app/components/header/header.component.html
+++ b/frontend/agentes-frontend/src/app/components/header/header.component.html
@@ -4,9 +4,7 @@
     <!-- 🔹 Esquerda: Hambúrguer (mobile) + Marca (desktop) -->
     <div class="d-flex align-items-center">
       <!-- Botão hamburguer (mobile) -->
-      <button class="btn d-lg-none me-2" (click)="toggleSidebar()">
-        <i class="fas fa-bars fa-lg"></i>
-      </button>
+      <app-button type="ghost" size="sm" iconLeft="fas fa-bars fa-lg" (clicked)="toggleSidebar()"></app-button>
 
       <!-- Marca (desktop) -->
       <div class="d-none d-lg-flex align-items-center">

--- a/frontend/agentes-frontend/src/app/components/header/header.component.ts
+++ b/frontend/agentes-frontend/src/app/components/header/header.component.ts
@@ -6,11 +6,12 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { LogoComponent } from '../../shared/general/logo/logo.component';
 import { MarcaComponent } from '../../shared/general/marca/marca.component';
+import { ButtonComponent } from '../../shared/components/buttons/button/button.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [CommonModule, RouterModule, LogoComponent, MarcaComponent],
+  imports: [CommonModule, RouterModule, LogoComponent, MarcaComponent, ButtonComponent],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })


### PR DESCRIPTION
## Summary
- import ButtonComponent into header and replace old mobile button with new component

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4355e60833188e933ca8872ac07