### PR TITLE
feat: use button component in sidebar

### DIFF
--- a/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.html
+++ b/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.html
@@ -3,9 +3,7 @@
   <!-- Cabeçalho do Sidebar -->
   <div class="sidebar-header d-flex justify-content-between align-items-center mb-3 d-lg-none">
     <app-logo variant="color" width="120px"></app-logo>
-    <button class="btn-close-sidebar" (click)="closeSidebar()">
-      <i class="fas fa-times"></i>
-    </button>
+    <app-button type="ghost" size="sm" iconLeft="fas fa-times" (clicked)="closeSidebar()"></app-button>
   </div>
 
   <!-- Links de navegação -->

--- a/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.ts
+++ b/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { NgIf } from '@angular/common';
 import { LogoComponent } from '../../shared/general/logo/logo.component';
+import { ButtonComponent } from '../../shared/components/buttons/button/button.component';
 import { Usuario } from '../../models/interfaces';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-sidebar',
   standalone: true,
-  imports: [LogoComponent, RouterLink, RouterLinkActive, NgIf], // 👈 aqui
+  imports: [LogoComponent, RouterLink, RouterLinkActive, NgIf, ButtonComponent], // 👈 aqui
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })


### PR DESCRIPTION
## Summary
- use shared button component in sidebar close action
- replace raw button in sidebar template

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d6b210ac8331b7541a52af0a17c1