### PR TITLE
feat: add accordion component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.html
@@ -1,0 +1,41 @@
+<div class="accordion">
+  <ng-container *ngIf="!loading; else skeleton">
+    <div
+      class="accordion-item"
+      *ngFor="let item of items; let i = index"
+      [ngClass]="[type, size, { disabled: item.disabled, expanded: expandedIndex === i }]"
+    >
+      <div
+        class="accordion-header"
+        (click)="toggleItem(i)"
+        [ngClass]="{ disabled: item.disabled }"
+        [attr.aria-expanded]="expandedIndex === i"
+        [attr.aria-controls]="'accordion-content-' + i"
+        [attr.aria-disabled]="item.disabled"
+      >
+        <ng-container *ngIf="iconLeft">
+          <i [ngClass]="iconLeft"></i>
+        </ng-container>
+        <span class="accordion-title">{{ item.title }}</span>
+        <ng-container *ngIf="iconRight">
+          <i [ngClass]="iconRight"></i>
+        </ng-container>
+        <i class="fa fa-chevron-down arrow" [ngClass]="{ rotated: expandedIndex === i }"></i>
+      </div>
+      <div class="accordion-content" [id]="'accordion-content-' + i">
+        <p>{{ item.content }}</p>
+      </div>
+    </div>
+  </ng-container>
+</div>
+
+<ng-template #skeleton>
+  <div class="accordion-item" *ngFor="let _ of skeletonItems">
+    <div class="accordion-header">
+      <div class="skeleton-title"></div>
+    </div>
+    <div class="accordion-content">
+      <div class="skeleton-content"></div>
+    </div>
+  </div>
+</ng-template>

--- a/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.scss
@@ -1,0 +1,164 @@
+@import "../../general/colors/colors.scss";
+
+.accordion-item {
+  border: 1px solid $neutral-200;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.accordion-header {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  transition: background 0.3s ease;
+}
+
+.accordion-header.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.arrow {
+  transition: transform 0.3s ease;
+}
+
+.arrow.rotated {
+  transform: rotate(180deg);
+}
+
+.accordion-content {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+  padding: 0 1rem;
+}
+
+.accordion-item.expanded .accordion-content {
+  max-height: 500px;
+  padding: 1rem;
+}
+
+/* Types */
+.accordion-item.primary {
+  border-color: $red-800;
+}
+
+.accordion-item.primary .accordion-header {
+  background: $red-800;
+  color: #fff;
+}
+
+.accordion-item.primary .accordion-header:hover {
+  background: $red-700;
+}
+
+.accordion-item.primary.expanded .accordion-header {
+  background: $red-900;
+}
+
+.accordion-item.secondary {
+  border-color: $neutral-700;
+}
+
+.accordion-item.secondary .accordion-header {
+  background: $neutral-700;
+  color: #fff;
+}
+
+.accordion-item.secondary .accordion-header:hover {
+  background: $neutral-600;
+}
+
+.accordion-item.secondary.expanded .accordion-header {
+  background: $neutral-800;
+}
+
+.accordion-item.danger {
+  border-color: $red-600;
+}
+
+.accordion-item.danger .accordion-header {
+  background: $red-600;
+  color: #fff;
+}
+
+.accordion-item.danger .accordion-header:hover {
+  background: $red-500;
+}
+
+.accordion-item.danger.expanded .accordion-header {
+  background: $red-700;
+}
+
+.accordion-item.ghost {
+  border-color: $red-800;
+}
+
+.accordion-item.ghost .accordion-header {
+  background: transparent;
+  color: $red-800;
+}
+
+.accordion-item.ghost .accordion-header:hover {
+  background: $red-50;
+}
+
+.accordion-item.ghost.expanded .accordion-header {
+  background: $red-100;
+}
+
+.accordion-item.ghost.disabled {
+  border-color: $neutral-300;
+}
+
+.accordion-item.ghost.disabled .accordion-header {
+  color: $neutral-300;
+}
+
+/* Sizes */
+.accordion-item.sm .accordion-header {
+  font-size: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.accordion-item.md .accordion-header {
+  font-size: 0.875rem;
+  padding: 0.75rem 1rem;
+}
+
+.accordion-item.lg .accordion-header {
+  font-size: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+/* Skeleton */
+.skeleton-title {
+  background: $neutral-200;
+  height: 1rem;
+  width: 50%;
+  border-radius: 4px;
+}
+
+.skeleton-content {
+  background: $neutral-200;
+  height: 0.75rem;
+  width: 80%;
+  margin: 0.5rem 0;
+  border-radius: 4px;
+}
+
+@media (max-width: 480px) {
+  .accordion-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .accordion-item,
+  .accordion-content {
+    width: 100%;
+  }
+}
+

--- a/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/accordion/accordion.component.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgFor, NgIf, NgClass } from '@angular/common';
+
+interface AccordionItem {
+  title: string;
+  content: string;
+  disabled?: boolean;
+}
+
+@Component({
+  selector: 'app-accordion',
+  standalone: true,
+  imports: [NgFor, NgIf, NgClass],
+  templateUrl: './accordion.component.html',
+  styleUrls: ['./accordion.component.scss'],
+})
+export class AccordionComponent {
+  @Input() items: AccordionItem[] = [];
+  @Input() type: 'primary' | 'secondary' | 'danger' | 'ghost' = 'primary';
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() iconLeft?: string;
+  @Input() iconRight?: string;
+  @Input() loading: boolean = false;
+
+  @Output() toggled = new EventEmitter<number>();
+
+  expandedIndex: number | null = null;
+  skeletonItems = Array(3);
+
+  toggleItem(index: number): void {
+    if (this.loading) {
+      return;
+    }
+
+    const item = this.items[index];
+    if (item?.disabled) {
+      return;
+    }
+
+    this.expandedIndex = this.expandedIndex === index ? null : index;
+    this.toggled.emit(index);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add standalone accordion component with types, sizes and icons
- include skeleton loading state and arrow rotation

## Testing
- `npm test` (fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)

------
https://chatgpt.com/codex/tasks/task_e_68a61d14afb08331a09905bf26f16a42