### PR TITLE
feat: add alert component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.html
@@ -1,0 +1,13 @@
+<div
+  *ngIf="visible"
+  class="alert"
+  [ngClass]="[type, size]"
+  role="alert"
+  aria-live="polite"
+  @fade
+>
+  <i *ngIf="iconLeft" class="{{ iconLeft }} alert-icon-left"></i>
+  <span class="alert-message">{{ message }}</span>
+  <i *ngIf="iconRight" class="{{ iconRight }} alert-icon-right"></i>
+  <button *ngIf="dismissible" class="alert-close" (click)="onDismiss()">&times;</button>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.scss
@@ -1,0 +1,86 @@
+@import "../../general/colors/colors.scss";
+
+.alert {
+  display: flex;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+
+  .alert-message {
+    flex: 1 1 auto;
+  }
+
+  .alert-icon-left,
+  .alert-icon-right {
+    margin: 0 0.5rem;
+  }
+
+  .alert-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    margin-left: 0.5rem;
+  }
+}
+
+/* Types */
+.alert.primary {
+  background: $blue-100;
+  border-color: $blue-200;
+  color: $blue-800;
+}
+
+.alert.secondary {
+  background: $neutral-100;
+  border-color: $neutral-200;
+  color: $neutral-800;
+}
+
+.alert.danger {
+  background: $red-100;
+  border-color: $red-200;
+  color: $red-800;
+}
+
+.alert.ghost {
+  background: transparent;
+  border-color: $neutral-200;
+  color: $neutral-800;
+}
+
+/* Sizes */
+.alert.sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.alert.md {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+
+.alert.lg {
+  padding: 0.75rem 1.25rem;
+  font-size: 1rem;
+}
+
+@media (max-width: 480px) {
+  .alert {
+    width: 100%;
+    flex-wrap: wrap;
+    text-align: center;
+
+    .alert-icon-left,
+    .alert-icon-right,
+    .alert-message {
+      flex-basis: 100%;
+      margin: 0.25rem 0;
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/alert/alert.component.ts
@@ -1,0 +1,35 @@
+import { CommonModule, NgClass, NgIf } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
+
+@Component({
+  selector: 'app-alert',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgIf],
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.scss'],
+  animations: [
+    trigger('fade', [
+      transition(':enter', [style({ opacity: 0 }), animate('150ms ease-in', style({ opacity: 1 }))]),
+      transition(':leave', [animate('150ms ease-out', style({ opacity: 0 }))]),
+    ]),
+  ],
+})
+export class AlertComponent {
+  @Input() type: 'primary' | 'secondary' | 'danger' | 'ghost' = 'primary';
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() message: string = '';
+  @Input() iconLeft?: string;
+  @Input() iconRight?: string;
+  @Input() dismissible: boolean = false;
+
+  @Output() dismissed = new EventEmitter<void>();
+
+  visible = true;
+
+  onDismiss(): void {
+    this.visible = false;
+    this.dismissed.emit();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add standalone AlertComponent with type, size, icons and dismissible options

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a625b4b48883319da29bc491737f67