### PR TITLE
feat: add standalone checkbox component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.html
@@ -1,0 +1,26 @@
+<label class="checkbox-container" [ngClass]="{ 'checked': checked, 'disabled': disabled, 'error': errorMessage, 'warning': warningMessage && !errorMessage }">
+  <input
+    type="checkbox"
+    [checked]="checked"
+    [disabled]="disabled"
+    [attr.name]="name"
+    [attr.value]="value"
+    (change)="onChange($event)"
+    role="checkbox"
+    [attr.aria-checked]="checked"
+    [attr.aria-invalid]="errorMessage ? true : null"
+    [attr.aria-disabled]="disabled"
+  />
+  <span class="check-icon"><i class="fa fa-check" aria-hidden="true"></i></span>
+  <span class="checkbox-label">{{ label }}</span>
+</label>
+<div class="messages">
+  <div *ngIf="errorMessage" class="error-message">
+    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+    <span>{{ errorMessage }}</span>
+  </div>
+  <div *ngIf="!errorMessage && warningMessage" class="warning-message">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    <span>{{ warningMessage }}</span>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.scss
@@ -1,0 +1,100 @@
+@import '../../general/colors/colors.scss';
+
+.checkbox-container {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.checkbox-container input {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  border: 2px solid $neutral-400;
+  border-radius: 4px;
+  background: #fff;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.checkbox-container input:hover:not(:disabled) {
+  border-color: $blue-500;
+}
+
+.checkbox-container.checked input {
+  background-color: $blue-600;
+  border-color: $blue-600;
+}
+
+.checkbox-container.disabled {
+  cursor: not-allowed;
+}
+
+.checkbox-container.disabled input {
+  border-color: $neutral-300;
+  background-color: $neutral-100;
+}
+
+.checkbox-container.error input {
+  border-color: $red-500;
+}
+
+.checkbox-container.warning input {
+  border-color: $yellow-500;
+}
+
+.check-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.checkbox-container.checked .check-icon {
+  opacity: 1;
+}
+
+.checkbox-label {
+  margin-left: 8px;
+  color: $neutral-800;
+}
+
+.messages {
+  margin-top: 4px;
+  font-size: 12px;
+}
+
+.error-message,
+.warning-message {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.error-message {
+  color: $red-600;
+}
+
+.warning-message {
+  color: $yellow-600;
+}
+
+@media (max-width: 480px) {
+  .checkbox-container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .checkbox-label {
+    margin-left: 0;
+    margin-top: 4px;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-checkbox',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './checkbox.component.html',
+  styleUrls: ['./checkbox.component.scss']
+})
+export class CheckboxComponent {
+  /** Texto exibido ao lado do checkbox */
+  @Input() label: string = '';
+  /** Estado atual do checkbox */
+  @Input() checked: boolean = false;
+  /** Desabilita o checkbox */
+  @Input() disabled: boolean = false;
+  /** Mensagem de erro exibida abaixo do checkbox */
+  @Input() errorMessage?: string;
+  /** Mensagem de aviso exibida abaixo do checkbox */
+  @Input() warningMessage?: string;
+  /** Nome do campo */
+  @Input() name?: string;
+  /** Valor do campo */
+  @Input() value?: string;
+
+  /** Emitido quando o valor do checkbox muda */
+  @Output() changed = new EventEmitter<boolean>();
+
+  onChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.checked = input.checked;
+    this.changed.emit(this.checked);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable checkbox component with accessibility attributes
- support error and warning messages with icon styling
- include responsive and state-based styling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99d19b28833183e01bcb4e31ab4d