### PR TITLE
feat: add checkbox group component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.html
@@ -1,0 +1,23 @@
+<div class="checkbox-group">
+  <p class="group-label">{{ groupLabel }}</p>
+  <div class="options">
+    <app-checkbox
+      *ngFor="let option of options"
+      [label]="option.label"
+      [value]="option.value"
+      [checked]="option.checked"
+      [disabled]="option.disabled"
+      (changed)="onOptionChanged(option.value, $event)"
+    ></app-checkbox>
+  </div>
+  <div class="messages">
+    <div *ngIf="errorMessage" class="error-message">
+      <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+      <span>{{ errorMessage }}</span>
+    </div>
+    <div *ngIf="!errorMessage && warningMessage" class="warning-message">
+      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+      <span>{{ warningMessage }}</span>
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.scss
@@ -1,0 +1,46 @@
+@import '../../general/colors/colors.scss';
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.group-label {
+  margin-bottom: 8px;
+  color: $neutral-800;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.messages {
+  margin-top: 4px;
+  font-size: 12px;
+}
+
+.error-message,
+.warning-message {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.error-message {
+  color: $red-600;
+}
+
+.warning-message {
+  color: $yellow-600;
+}
+
+@media (max-width: 480px) {
+  .group-label {
+    margin-bottom: 4px;
+  }
+  .options {
+    gap: 4px;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/checkbox/checkbox-group.component.ts
@@ -1,0 +1,57 @@
+import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CheckboxComponent } from './checkbox.component';
+
+interface CheckboxOption {
+  label: string;
+  value: string;
+  checked?: boolean;
+  disabled?: boolean;
+}
+
+@Component({
+  selector: 'app-checkbox-group',
+  standalone: true,
+  imports: [CheckboxComponent, CommonModule],
+  templateUrl: './checkbox-group.component.html',
+  styleUrls: ['./checkbox-group.component.scss'],
+})
+export class CheckboxGroupComponent implements OnChanges {
+  /** Label do grupo de checkboxes */
+  @Input() groupLabel: string = '';
+  /** Lista de opções a serem exibidas */
+  @Input() options: CheckboxOption[] = [];
+  /** Mensagem de erro exibida abaixo do grupo */
+  @Input() errorMessage?: string;
+  /** Mensagem de aviso exibida abaixo do grupo */
+  @Input() warningMessage?: string;
+
+  /** Emitido quando os valores selecionados mudam */
+  @Output() changed = new EventEmitter<string[]>();
+
+  /** Lista local de valores selecionados */
+  selectedValues: string[] = [];
+
+  ngOnChanges(): void {
+    this.selectedValues = this.options
+      .filter(option => option.checked)
+      .map(option => option.value);
+  }
+
+  onOptionChanged(value: string, checked: boolean): void {
+    const option = this.options.find(o => o.value === value);
+    if (option) {
+      option.checked = checked;
+    }
+
+    if (checked) {
+      if (!this.selectedValues.includes(value)) {
+        this.selectedValues.push(value);
+      }
+    } else {
+      this.selectedValues = this.selectedValues.filter(v => v !== value);
+    }
+    this.changed.emit([...this.selectedValues]);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add standalone checkbox group component with error and warning messages
- style checkbox group with shared color scheme and responsive layout

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad9afb94f48331920eaca54ce1efa5