### PR TITLE
feat: add content switcher component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.html
@@ -1,0 +1,15 @@
+<div class="content-switcher" role="tablist" [attr.aria-label]="ariaLabel" [ngClass]="[type, size]" (keydown)="onKeydown($event)">
+  <button
+    *ngFor="let option of options; let i = index"
+    #optionBtn
+    type="button"
+    role="tab"
+    [disabled]="option.disabled"
+    [ngClass]="{ 'selected': option.value === selected, 'disabled': option.disabled }"
+    [attr.aria-selected]="option.value === selected"
+    [attr.aria-disabled]="option.disabled || null"
+    (click)="onSelect(option.value, option.disabled)">
+    <i *ngIf="type === 'with-icons' && option.icon" class="{{ option.icon }}"></i>
+    {{ option.label }}
+  </button>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.scss
@@ -1,0 +1,70 @@
+@import "../../general/colors/colors.scss";
+
+.content-switcher {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+
+  button {
+    border: 1px solid $neutral-200;
+    background: transparent;
+    color: $neutral-800;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    transition: background 0.2s ease, color 0.2s ease;
+
+    &.selected {
+      background: $red-800;
+      border-color: $red-800;
+      color: #fff;
+    }
+
+    &:hover:not(.disabled):not(.selected) {
+      background: $neutral-100;
+    }
+
+    &.disabled {
+      background: $neutral-100;
+      color: $neutral-400;
+      cursor: not-allowed;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $blue-600;
+      outline-offset: 2px;
+    }
+  }
+
+  &.with-icons button i {
+    margin-right: 0.25rem;
+  }
+
+  &.sm button {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+  }
+
+  &.md button {
+    font-size: 0.875rem;
+    padding: 0.5rem 1rem;
+  }
+
+  &.lg button {
+    font-size: 1rem;
+    padding: 0.75rem 1.25rem;
+  }
+
+  &.vertical {
+    flex-direction: column;
+  }
+
+  &.horizontal,
+  &.default,
+  &.with-icons {
+    flex-direction: row;
+  }
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/content-switcher/content-switcher.component.ts
@@ -1,0 +1,54 @@
+import { Component, EventEmitter, Input, Output, ViewChildren, QueryList, ElementRef } from '@angular/core';
+import { CommonModule, NgClass, NgFor } from '@angular/common';
+
+@Component({
+  selector: 'app-content-switcher',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgFor],
+  templateUrl: './content-switcher.component.html',
+  styleUrls: ['./content-switcher.component.scss'],
+})
+export class ContentSwitcherComponent {
+  @Input() options: { label: string; value: string; icon?: string; disabled?: boolean }[] = [];
+  @Input() selected: string = '';
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() ariaLabel: string = 'content switcher';
+  @Input() type: 'default' | 'with-icons' | 'horizontal' | 'vertical' = 'default';
+
+  @Output() selectedChange = new EventEmitter<string>();
+
+  @ViewChildren('optionBtn') optionButtons!: QueryList<ElementRef<HTMLButtonElement>>;
+
+  onSelect(value: string, disabled?: boolean): void {
+    if (disabled) {
+      return;
+    }
+    this.selected = value;
+    this.selectedChange.emit(this.selected);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    const validKeys = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'];
+    if (!validKeys.includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = this.options.findIndex(o => o.value === this.selected);
+    const startIndex = currentIndex === -1 ? 0 : currentIndex;
+    const step = event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1;
+    const newIndex = this.findNextEnabledIndex(startIndex, step);
+    const option = this.options[newIndex];
+    this.onSelect(option.value, option.disabled);
+    this.optionButtons.get(newIndex)?.nativeElement.focus();
+  }
+
+  private findNextEnabledIndex(start: number, step: number): number {
+    const len = this.options.length;
+    let idx = start;
+    do {
+      idx = (idx + step + len) % len;
+    } while (this.options[idx].disabled && idx !== start);
+    return idx;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add standalone `ContentSwitcherComponent` with keyboard navigation and selection events
- style switcher with DS variables and responsive layout

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ada5ca627083318354c15460a46811