### PR TITLE
feat: add carbon-styled file uploader

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.html
@@ -1,0 +1,43 @@
+<li
+  class="uploader-item"
+  [ngClass]="[size, state, disabled ? 'is-disabled' : '']"
+  role="listitem"
+  tabindex="0"
+  (keydown)="onKeydown($event)"
+  [attr.aria-busy]="state === 'uploading' ? 'true' : null"
+  [attr.aria-invalid]="state === 'error' ? 'true' : null"
+  [attr.aria-disabled]="disabled ? 'true' : null"
+>
+  <div class="item-content">
+    <span class="file-name">{{ fileName }}</span>
+    <i *ngIf="state === 'uploading'" class="fa fa-spinner spin" aria-hidden="true"></i>
+    <i *ngIf="state === 'success'" class="fa fa-check-circle" aria-hidden="true"></i>
+    <i *ngIf="state === 'error'" class="fa fa-exclamation-circle" aria-hidden="true"></i>
+    <button
+      *ngIf="removable && !disabled"
+      type="button"
+      class="btn-remove"
+      [attr.aria-label]="removeLabel"
+      (click)="remove.emit()"
+    >
+      <i class="fa fa-times" aria-hidden="true"></i>
+    </button>
+  </div>
+  <div
+    *ngIf="state === 'error' && errorPrimary"
+    class="error-message"
+    role="alert"
+    aria-live="polite"
+  >
+    <span class="primary">{{ errorPrimary }}</span>
+    <span *ngIf="errorSecondary" class="secondary">{{ errorSecondary }}</span>
+    <button
+      *ngIf="!disabled"
+      type="button"
+      class="retry"
+      (click)="retry.emit()"
+    >
+      {{ retryLabel }}
+    </button>
+  </div>
+</li>

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.scss
@@ -1,0 +1,82 @@
+@import "../../general/colors/colors.scss";
+
+.uploader-item {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  background: $neutral-50;
+  border: 1px solid $neutral-200;
+  border-radius: 4px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  transition: background 150ms ease-out, border-color 150ms ease-out;
+  font-size: 14px;
+  line-height: 1.4;
+
+  &.sm { padding: 4px 8px; font-size: 12px; }
+  &.lg { padding: 12px 16px; font-size: 16px; }
+
+  &.error { border-color: $red-800; }
+  &.is-disabled { opacity: 0.6; cursor: not-allowed; }
+
+  &:focus-visible { outline: none; box-shadow: 0 0 0 2px $blue-600; }
+
+  .item-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .file-name {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .btn-remove {
+    background: none;
+    border: 0;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    color: $neutral-600;
+    border-radius: 4px;
+    transition: background 150ms ease-out, color 150ms ease-out;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover { background: $neutral-100; }
+    &:focus-visible { outline: none; box-shadow: 0 0 0 2px $blue-600; }
+  }
+
+  .error-message {
+    margin-top: 4px;
+    color: $red-800;
+    line-height: 1.3;
+
+    .secondary { display: block; margin-top: 2px; }
+
+    button.retry {
+      margin-top: 4px;
+      background: none;
+      border: 0;
+      color: $blue-600;
+      text-decoration: underline;
+      cursor: pointer;
+      padding: 0;
+      font: inherit;
+      &:focus-visible { outline: none; box-shadow: 0 0 0 2px $blue-600; }
+    }
+  }
+
+  i.fa-spinner { margin-left: 4px; }
+}
+
+.spin { animation: spin 1s linear infinite; }
+@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+
+@media (max-width: 480px) {
+  .uploader-item { width: 100%; }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader-item.component.ts
@@ -1,0 +1,44 @@
+import { CommonModule, NgClass, NgIf } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-file-uploader-item',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgIf],
+  templateUrl: './file-uploader-item.component.html',
+  styleUrls: ['./file-uploader-item.component.scss'],
+})
+export class FileUploaderItemComponent {
+  @Input() fileName!: string;
+  @Input() state: 'idle' | 'uploading' | 'success' | 'error' = 'idle';
+  @Input() progress: number = 0;
+  @Input() errorPrimary?: string;
+  @Input() errorSecondary?: string;
+  @Input() removable: boolean = true;
+  @Input() disabled: boolean = false;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() removeLabel: string = 'Remover';
+  @Input() retryLabel: string = 'Tentar novamente';
+
+  @Output() remove = new EventEmitter<void>();
+  @Output() retry = new EventEmitter<void>();
+  @Output() focusPrev = new EventEmitter<void>();
+  @Output() focusNext = new EventEmitter<void>();
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Delete' && this.removable) {
+      event.preventDefault();
+      this.remove.emit();
+    } else if (event.key === 'Enter' && this.state === 'error') {
+      event.preventDefault();
+      this.retry.emit();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.focusPrev.emit();
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.focusNext.emit();
+    }
+  }
+}
+

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.html
@@ -1,0 +1,68 @@
+<div class="file-uploader" [ngClass]="[size, variant, fluid ? 'is-fluid' : '', disabled ? 'is-disabled' : '']">
+  <label *ngIf="label" class="uploader-label">{{ label }}</label>
+  <p *ngIf="helperText" class="uploader-helper">{{ helperText }}</p>
+
+  <input
+    #fileInput
+    class="visually-hidden"
+    type="file"
+    [multiple]="multiple"
+    [accept]="acceptAsString"
+    (change)="onFileInputChange($event)"
+    [disabled]="disabled"
+  />
+
+  <button
+    *ngIf="variant === 'button' || variant === 'both'"
+    type="button"
+    class="uploader-button"
+    [disabled]="disabled"
+    (click)="openFileDialog()"
+    (keydown.enter)="openFileDialog()"
+    (keydown.space)="openFileDialog()"
+  >
+    {{ label || t.dragDrop }}
+  </button>
+
+  <div
+    *ngIf="variant === 'dropzone' || variant === 'both'"
+    class="dropzone"
+    role="button"
+    tabindex="0"
+    [attr.aria-label]="t.dragDrop"
+    [ngClass]="{ 'is-active': dragActive, 'is-error': dropzoneError, 'is-disabled': disabled }"
+    (click)="openFileDialog()"
+    (keydown)="onDropzoneKeydown($event)"
+    (dragenter)="onDragOver($event)"
+    (dragover)="onDragOver($event)"
+    (dragleave)="onDragLeave($event)"
+    (drop)="onDropEvent($event)"
+  >
+    <span>{{ t.dragDrop }}</span>
+  </div>
+
+  <ul class="uploader-list" role="list">
+    <app-file-uploader-item
+      *ngFor="let item of items; let i = index"
+      [fileName]="item.name"
+      [state]="item.state"
+      [progress]="item.progress"
+      [errorPrimary]="item.errorPrimary"
+      [errorSecondary]="item.errorSecondary"
+      [removable]="!disabled"
+      [disabled]="disabled"
+      [size]="size"
+      [removeLabel]="t.remove"
+      [retryLabel]="t.retry"
+      (remove)="onRemove(item)"
+      (retry)="retryItem(item)"
+      (focusPrev)="handleFocusPrev(i)"
+      (focusNext)="handleFocusNext(i)"
+    ></app-file-uploader-item>
+  </ul>
+
+  <div *ngIf="showSkeleton" class="skeleton">
+    <div class="sk-line"></div>
+    <div class="sk-line"></div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.scss
@@ -1,0 +1,110 @@
+@import "../../general/colors/colors.scss";
+
+.file-uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: fit-content;
+
+  &.is-fluid {
+    width: 100%;
+  }
+
+  &.is-disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  .uploader-label {
+    font-weight: 700;
+  }
+
+  .uploader-helper {
+    font-size: 14px;
+    color: $neutral-600;
+  }
+
+  .uploader-button {
+    background: $red-800;
+    color: #fff;
+    border: 0;
+    border-radius: 4px;
+    padding: 8px 16px;
+    cursor: pointer;
+    transition: background 150ms ease-out;
+    font-size: 14px;
+
+    &:hover:not(:disabled) { background: $red-700; }
+    &:active:not(:disabled) { background: $red-900; }
+    &:disabled { background: $neutral-300; cursor: not-allowed; }
+    &:focus-visible { outline: none; box-shadow: 0 0 0 2px $blue-600; }
+  }
+
+  .dropzone {
+    border: 2px dashed $neutral-400;
+    border-radius: 4px;
+    padding: 16px;
+    cursor: pointer;
+    transition: border-color 150ms ease-out, background 150ms ease-out;
+    color: $neutral-600;
+    background: $neutral-50;
+
+    &.is-active { border-style: solid; border-color: $neutral-600; }
+    &.is-error { border-color: $red-800; border-style: solid; color: $red-800; }
+    &.is-disabled { border-color: $neutral-200; color: $neutral-200; cursor: not-allowed; }
+    &:hover:not(.is-disabled) { border-style: solid; border-color: $neutral-600; }
+    &:focus-visible { outline: none; box-shadow: 0 0 0 2px $blue-600; }
+  }
+
+  .uploader-list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .skeleton {
+    .sk-line {
+      height: 16px;
+      background: $neutral-200;
+      border-radius: 4px;
+      overflow: hidden;
+      position: relative;
+      margin-bottom: 8px;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -100%;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(90deg, transparent, $neutral-100, transparent);
+        animation: shimmer 1.2s infinite;
+      }
+    }
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes shimmer {
+  100% { transform: translateX(100%); }
+}
+
+@media (max-width: 480px) {
+  .file-uploader,
+  .file-uploader .uploader-button,
+  .file-uploader .dropzone {
+    width: 100%;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.component.ts
@@ -1,0 +1,294 @@
+import { CommonModule, NgClass, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+import { FileUploaderItemComponent } from './file-uploader-item.component';
+
+export interface UploadItem {
+  file: File;
+  name: string;
+  state: 'idle' | 'uploading' | 'success' | 'error';
+  progress: number;
+  errorPrimary?: string;
+  errorSecondary?: string;
+}
+
+interface Translations {
+  dragDrop: string;
+  remove: string;
+  retry: string;
+  errorSize: string;
+  errorType: string;
+  uploading: string;
+  success: string;
+}
+
+@Component({
+  selector: 'app-file-uploader',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgFor, NgIf, NgTemplateOutlet, FileUploaderItemComponent],
+  templateUrl: './file-uploader.component.html',
+  styleUrls: ['./file-uploader.component.scss'],
+})
+export class FileUploaderComponent {
+  @Input() label?: string;
+  @Input() helperText?: string;
+  @Input() accept?: string | string[];
+  @Input() maxFileSize?: number;
+  @Input() maxFiles?: number;
+  @Input() multiple: boolean = true;
+  @Input() disabled: boolean = false;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() variant: 'button' | 'dropzone' | 'both' = 'button';
+  @Input() fluid: boolean = false;
+  @Input() autoUpload: boolean = false;
+  @Input() showSkeleton: boolean = false;
+  @Input() uploader?: (file: File) => Observable<number>;
+  @Input() translations: Partial<Translations> = {};
+
+  @Output() filesChange = new EventEmitter<File[]>();
+  @Output() fileAdded = new EventEmitter<{ file: File }>();
+  @Output() fileRemoved = new EventEmitter<{ file: File }>();
+  @Output() uploadStart = new EventEmitter<{ files: File[] }>();
+  @Output() uploadProgress = new EventEmitter<{ file: File; progress: number }>();
+  @Output() uploadSuccess = new EventEmitter<{ file: File }>();
+  @Output() uploadError = new EventEmitter<{ file: File; message: string }>();
+  @Output() drop = new EventEmitter<{ files: File[] }>();
+
+  @ViewChild('fileInput') fileInput?: ElementRef<HTMLInputElement>;
+  @ViewChildren(FileUploaderItemComponent, { read: ElementRef })
+  itemElements!: QueryList<ElementRef<HTMLElement>>;
+
+  items: UploadItem[] = [];
+  dragActive = false;
+  dropzoneError = false;
+
+  private defaultTranslations: Translations = {
+    dragDrop: 'Arraste e solte os arquivos aqui ou clique para enviar',
+    remove: 'Remover',
+    retry: 'Tentar novamente',
+    errorSize: 'Arquivo ultrapassa o limite de tamanho.',
+    errorType: 'Tipo de arquivo não suportado.',
+    uploading: 'Enviando...',
+    success: 'Enviado',
+  };
+
+  get t(): Translations {
+    return { ...this.defaultTranslations, ...this.translations } as Translations;
+  }
+
+  get acceptAsString(): string | undefined {
+    if (!this.accept) return undefined;
+    return Array.isArray(this.accept) ? this.accept.join(',') : this.accept;
+  }
+
+  openFileDialog(): void {
+    if (this.disabled) return;
+    this.fileInput?.nativeElement.click();
+  }
+
+  onFileInputChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = Array.from(input.files || []);
+    this.addFiles(files);
+    input.value = '';
+  }
+
+  addFiles(files: File[]): void {
+    for (const file of files) {
+      if (this.maxFiles && this.items.length >= this.maxFiles) {
+        this.items.push({
+          file,
+          name: file.name,
+          state: 'error',
+          progress: 0,
+          errorPrimary: 'Too many files.',
+        });
+        this.dropzoneError = true;
+        continue;
+      }
+      if (this.isDuplicate(file)) {
+        continue;
+      }
+      const error = this.validateFile(file);
+      if (error) {
+        this.items.push({
+          file,
+          name: file.name,
+          state: 'error',
+          progress: 0,
+          errorPrimary: error,
+        });
+        this.dropzoneError = true;
+        continue;
+      }
+      const item: UploadItem = {
+        file,
+        name: file.name,
+        state: 'idle',
+        progress: 0,
+      };
+      this.items.push(item);
+      this.fileAdded.emit({ file });
+      if (this.autoUpload) {
+        this.startUpload([item]);
+      }
+    }
+    this.emitFilesChange();
+  }
+
+  validateFile(file: File): string | null {
+    if (this.accept) {
+      const acceptList = Array.isArray(this.accept)
+        ? this.accept
+        : this.accept.split(',');
+      const fileExt = '.' + (file.name.split('.').pop() || '').toLowerCase();
+      const mime = file.type;
+      const accepted = acceptList.some((a) => {
+        const acc = a.trim();
+        if (acc.endsWith('/*')) {
+          return mime.startsWith(acc.slice(0, acc.length - 1));
+        }
+        return acc === mime || acc.toLowerCase() === fileExt;
+      });
+      if (!accepted) return this.t.errorType;
+    }
+    if (this.maxFileSize && file.size > this.maxFileSize) {
+      return this.t.errorSize;
+    }
+    return null;
+  }
+
+  isDuplicate(file: File): boolean {
+    return this.items.some(
+      (i) =>
+        i.file.name === file.name &&
+        i.file.size === file.size &&
+        i.file.lastModified === file.lastModified
+    );
+  }
+
+  onDropEvent(event: DragEvent): void {
+    event.preventDefault();
+    if (this.disabled) return;
+    this.dragActive = false;
+    const files = Array.from(event.dataTransfer?.files || []);
+    if (files.length) {
+      this.addFiles(files);
+      this.drop.emit({ files });
+    }
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    if (this.disabled) return;
+    this.dragActive = true;
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.dragActive = false;
+  }
+
+  onDropzoneKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openFileDialog();
+    } else if (event.key === 'Escape') {
+      this.dragActive = false;
+    }
+  }
+
+  startUpload(items: UploadItem[] = this.items.filter((i) => i.state === 'idle')): void {
+    if (!items.length) return;
+    this.uploadStart.emit({ files: items.map((i) => i.file) });
+    for (const item of items) {
+      item.state = 'uploading';
+      item.progress = 0;
+      if (this.uploader) {
+        this.uploader(item.file).subscribe({
+          next: (p: number) => {
+            item.progress = p;
+            this.uploadProgress.emit({ file: item.file, progress: p });
+          },
+          error: (err: any) => {
+            item.state = 'error';
+            item.errorPrimary = String(err);
+            this.uploadError.emit({ file: item.file, message: String(err) });
+          },
+          complete: () => {
+            item.state = 'success';
+            item.progress = 100;
+            this.uploadSuccess.emit({ file: item.file });
+          },
+        });
+      } else {
+        const interval = setInterval(() => {
+          if (item.state !== 'uploading') {
+            clearInterval(interval);
+            return;
+          }
+          item.progress += 10;
+          this.uploadProgress.emit({ file: item.file, progress: item.progress });
+          if (item.progress >= 100) {
+            clearInterval(interval);
+            item.progress = 100;
+            if (Math.random() < 0.15) {
+              item.state = 'error';
+              item.errorPrimary = 'Upload failed.';
+              this.uploadError.emit({ file: item.file, message: 'Upload failed.' });
+            } else {
+              item.state = 'success';
+              this.uploadSuccess.emit({ file: item.file });
+            }
+          }
+        }, 200);
+      }
+    }
+  }
+
+  onRemove(item: UploadItem): void {
+    this.items = this.items.filter((i) => i !== item);
+    this.fileRemoved.emit({ file: item.file });
+    this.emitFilesChange();
+  }
+
+  retryItem(item: UploadItem): void {
+    item.state = 'idle';
+    item.errorPrimary = undefined;
+    item.errorSecondary = undefined;
+    this.startUpload([item]);
+  }
+
+  clear(): void {
+    this.items = [];
+    this.emitFilesChange();
+  }
+
+  handleFocusPrev(index: number): void {
+    const arr = this.itemElements.toArray();
+    if (index > 0) {
+      arr[index - 1].nativeElement.focus();
+    }
+  }
+
+  handleFocusNext(index: number): void {
+    const arr = this.itemElements.toArray();
+    if (index < arr.length - 1) {
+      arr[index + 1].nativeElement.focus();
+    }
+  }
+
+  emitFilesChange(): void {
+    this.filesChange.emit(this.items.map((i) => i.file));
+  }
+}
+

--- a/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.stories.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/file-uploader/file-uploader.stories.ts
@@ -1,0 +1,157 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { action } from '@storybook/addon-actions';
+import { FileUploaderComponent, UploadItem } from './file-uploader.component';
+
+const meta: Meta<FileUploaderComponent> = {
+  title: 'Shared/Components/FileUploader',
+  component: FileUploaderComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, FileUploaderComponent],
+    }),
+  ],
+  argTypes: {
+    variant: { control: 'select', options: ['button', 'dropzone', 'both'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    multiple: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    maxFiles: { control: 'number' },
+    maxFileSize: { control: 'number' },
+    accept: { control: 'text' },
+    autoUpload: { control: 'boolean' },
+    showSkeleton: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<FileUploaderComponent>;
+
+const idleItems: UploadItem[] = [
+  { file: new File([], 'Filename1.png'), name: 'Filename1.png', state: 'idle', progress: 0 },
+  { file: new File([], 'Filename2.png'), name: 'Filename2.png', state: 'idle', progress: 0 },
+  { file: new File([], 'Filename3.png'), name: 'Filename3.png', state: 'idle', progress: 0 },
+];
+
+export const DefaultButton: Story = {
+  args: {
+    label: 'Upload files',
+    helperText: 'Max file size is 500kb. Supported types: .jpg, .png',
+    variant: 'button',
+  },
+  render: (args) => ({
+    props: {
+      ...args,
+      items: idleItems.slice(),
+      filesChange: action('filesChange'),
+      uploadStart: action('uploadStart'),
+      uploadProgress: action('uploadProgress'),
+      uploadSuccess: action('uploadSuccess'),
+      uploadError: action('uploadError'),
+      fileRemoved: action('fileRemoved'),
+      drop: action('drop'),
+    },
+    template: `<app-file-uploader [label]="label" [helperText]="helperText" [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const Uploading: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      items: [
+        { file: new File([], 'Uploading.png'), name: 'Uploading.png', state: 'uploading', progress: 50 },
+      ],
+      variant: 'button',
+    },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const Success: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      items: [
+        { file: new File([], 'Done.png'), name: 'Done.png', state: 'success', progress: 100 },
+      ],
+      variant: 'button',
+    },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const ErrorSimple: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      items: [
+        {
+          file: new File([], 'BigFile.png'),
+          name: 'BigFile.png',
+          state: 'error',
+          progress: 0,
+          errorPrimary: 'File exceeds size limit.',
+        },
+      ],
+      variant: 'button',
+    },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const ErrorTwoLines: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      items: [
+        {
+          file: new File([], 'File.png'),
+          name: 'File.png',
+          state: 'error',
+          progress: 0,
+          errorPrimary: 'File exceeds size limit.',
+          errorSecondary: 'Optional secondary explanation that can go on for two lines.',
+        },
+      ],
+      variant: 'button',
+    },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const DropzoneDefault: Story = {
+  args: { variant: 'dropzone' },
+  render: (args) => ({
+    props: args,
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const DropzoneError: Story = {
+  args: { variant: 'dropzone' },
+  render: (args) => ({
+    props: { ...args, dropzoneError: true },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};
+
+export const Disabled: Story = {
+  render: (args) => ({
+    props: {
+      ...args,
+      disabled: true,
+      showSkeleton: true,
+      variant: 'both',
+    },
+    template: `<app-file-uploader [variant]="variant" [disabled]="disabled" [showSkeleton]="showSkeleton"></app-file-uploader>`,
+  }),
+};
+
+export const Both: Story = {
+  args: { variant: 'both' },
+  render: (args) => ({
+    props: { ...args, items: idleItems.slice() },
+    template: `<app-file-uploader [variant]="variant"></app-file-uploader>`,
+  }),
+};


### PR DESCRIPTION
## Summary
- add standalone file uploader and item components with drag-and-drop, validation, and progress states
- include Carbon-inspired styles, accessibility hooks, and skeleton placeholders
- document component with Storybook stories

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b82471e2f88331b2a3d38e2f4dcfc4