### PR TITLE
feat: add Carbon-style list component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/list/list.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/list/list.component.html
@@ -1,0 +1,28 @@
+<div class="list-root" [ngClass]="['size-' + size, type]" [attr.aria-label]="ariaLabel" role="group" tabindex="0">
+  <ng-template #render let-items let-level="level">
+    <ol *ngIf="type === 'ordered'; else unorderedTmpl"
+        [ngClass]="['lvl-' + level, columns === 2 && level === 1 ? 'columns-2' : '']"
+        [attr.start]="level === 1 && start !== null ? start : null">
+      <li *ngFor="let it of items" class="fade-in">
+        <span *ngIf="it.text">{{ it.text }}</span>
+        <span *ngIf="it.html" [innerHTML]="sanitize(it.html)"></span>
+        <ng-container *ngIf="it.children?.length">
+          <ng-container *ngTemplateOutlet="render; context: { $implicit: it.children, level: level + 1 }"></ng-container>
+        </ng-container>
+      </li>
+    </ol>
+    <ng-template #unorderedTmpl>
+      <ul [ngClass]="['lvl-' + level, columns === 2 && level === 1 ? 'columns-2' : '']">
+        <li *ngFor="let it of items" class="fade-in">
+          <span *ngIf="it.text">{{ it.text }}</span>
+          <span *ngIf="it.html" [innerHTML]="sanitize(it.html)"></span>
+          <ng-container *ngIf="it.children?.length">
+            <ng-container *ngTemplateOutlet="render; context: { $implicit: it.children, level: level + 1 }"></ng-container>
+          </ng-container>
+        </li>
+      </ul>
+    </ng-template>
+  </ng-template>
+
+  <ng-container *ngTemplateOutlet="render; context: { $implicit: items, level: 1 }"></ng-container>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/list/list.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/list/list.component.scss
@@ -1,0 +1,78 @@
+@import "../../general/colors/colors.scss";
+
+:host {
+  display: block;
+}
+
+.list-root {
+  color: $neutral-900;
+
+  &:focus {
+    outline: 2px solid $blue-600;
+    outline-offset: 2px;
+  }
+
+  ol, ul {
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+
+  li {
+    margin: 0.25rem 0;
+    line-height: 1.5;
+  }
+}
+
+.size-sm { font-size: 0.875rem; }
+.size-md { font-size: 1rem; }
+.size-lg { font-size: 1.125rem; }
+
+/* Ordered lists */
+ol.lvl-1 { list-style-type: decimal; }
+ol.lvl-2 { list-style-type: lower-alpha; }
+ol.lvl-3, ol.lvl-4, ol.lvl-5, ol.lvl-6 { list-style-type: lower-roman; }
+
+/* Unordered lists */
+ul { list-style: none; }
+ul.lvl-1 > li {
+  position: relative;
+  padding-left: 1rem;
+}
+ul.lvl-1 > li::before {
+  content: "\2013";
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+  color: $neutral-700;
+}
+ul:not(.lvl-1) > li {
+  position: relative;
+  padding-left: 1rem;
+}
+ul:not(.lvl-1) > li::before {
+  content: "\25A0";
+  font-size: 0.55rem;
+  position: absolute;
+  left: 0;
+  top: 0.35rem;
+  color: $neutral-700;
+}
+
+.columns-2 {
+  column-count: 2;
+  column-gap: 2rem;
+}
+@media (max-width: 480px) {
+  .columns-2 {
+    column-count: 1;
+  }
+}
+
+.fade-in {
+  animation: fadeIn 120ms ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(2px); }
+  to { opacity: 1; transform: none; }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/list/list.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/list/list.component.ts
@@ -1,0 +1,37 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule, NgClass } from '@angular/common';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+export type ListType = 'ordered' | 'unordered';
+export type ListSize = 'sm' | 'md' | 'lg';
+export interface ListItem {
+  text?: string;                 // texto simples
+  html?: string;                 // HTML seguro (usar [innerHTML] com sanitização)
+  children?: ListItem[];         // nós aninhados
+}
+
+@Component({
+  selector: 'app-list',
+  standalone: true,
+  imports: [CommonModule, NgClass],
+  templateUrl: './list.component.html',
+  styleUrls: ['./list.component.scss'],
+})
+export class ListComponent {
+  @Input() type: ListType = 'unordered';
+  @Input() items: ListItem[] = [];
+  @Input() size: ListSize = 'md';
+  @Input() columns: 1 | 2 = 1;
+  @Input() start: number | null = null;
+  @Input() ariaLabel: string = 'Lista';
+
+  constructor(private sanitizer: DomSanitizer) {}
+
+  /**
+   * Sanitiza HTML fornecido para uso seguro no template.
+   * A fonte deve ser confiável, pois bypassSecurityTrustHtml desativa a sanitização padrão.
+   */
+  sanitize(html: string): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone `app-list` component mirroring Carbon list styles
- support ordered/unordered markers, nested levels and optional two-column layout

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*

------
https://chatgpt.com/codex/tasks/task_e_68b973153a988331bd953f04fd20837a