### PR TITLE
feat: add menu buttons component for design system

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.html
@@ -1,0 +1,82 @@
+<div class="mb-wrapper" [ngClass]="[variant, type, size]">
+  <ng-container [ngSwitch]="variant">
+    <!-- Overflow -->
+    <button *ngSwitchCase="'overflow'"
+            type="button"
+            class="mb-trigger overflow"
+            [ngClass]="[type, size]"
+            (click)="toggleMenu()"
+            (keydown)="onTriggerKeydown($event)"
+            [disabled]="disabled"
+            role="button"
+            aria-haspopup="menu"
+            [attr.aria-expanded]="open"
+            [attr.aria-controls]="menuId">
+      <i [class]="icon" aria-hidden="true"></i>
+    </button>
+
+    <!-- Menu button -->
+    <button *ngSwitchCase="'menu'"
+            type="button"
+            class="mb-trigger menu"
+            [ngClass]="[type, size]"
+            (click)="toggleMenu()"
+            (keydown)="onTriggerKeydown($event)"
+            [disabled]="disabled"
+            role="button"
+            aria-haspopup="menu"
+            [attr.aria-expanded]="open"
+            [attr.aria-controls]="menuId">
+      <span class="mb-label">{{ label }}</span>
+      <i class="fa fa-chevron-down mb-caret" aria-hidden="true"></i>
+    </button>
+
+    <!-- Combo / Split button -->
+    <div *ngSwitchCase="'combo'" class="mb-combo-wrapper" [ngClass]="[type, size]">
+      <button type="button"
+              class="mb-trigger primary"
+              [ngClass]="[type, size]"
+              (click)="onPrimaryClick()"
+              [disabled]="disabled">
+        {{ label }}
+      </button>
+      <button type="button"
+              class="mb-trigger caret"
+              [ngClass]="[type, size]"
+              (click)="toggleMenu()"
+              (keydown)="onTriggerKeydown($event)"
+              [disabled]="disabled"
+              role="button"
+              aria-haspopup="menu"
+              [attr.aria-expanded]="open"
+              [attr.aria-controls]="menuId">
+        <i class="fa fa-chevron-down" aria-hidden="true"></i>
+      </button>
+    </div>
+  </ng-container>
+
+  <!-- Menu -->
+  <div class="mb-menu" #menu
+       [ngClass]="[placementClass, alignClass, size]"
+       role="menu"
+       [attr.aria-label]="label"
+       [style.width.px]="menuWidth"
+       *ngIf="open">
+    <ul class="mb-list">
+      <ng-container *ngFor="let it of items; let i = index">
+        <li *ngIf="it.dividerAbove" class="mb-divider" role="separator" aria-hidden="true"></li>
+        <li #menuItem
+            class="mb-item"
+            role="menuitem"
+            [attr.tabindex]="i === activeIndex ? 0 : -1"
+            [ngClass]="{ disabled: it.disabled, danger: it.danger }"
+            (click)="onItemClick(it)"
+            (keydown)="onItemKeydown($event, i)">
+          <i *ngIf="it.iconLeft" [class]="it.iconLeft" aria-hidden="true"></i>
+          <span class="mb-label">{{ it.label }}</span>
+          <small *ngIf="it.helperText" class="mb-helper">{{ it.helperText }}</small>
+        </li>
+      </ng-container>
+    </ul>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.scss
@@ -1,0 +1,142 @@
+@import "../../general/colors/colors.scss";
+
+$radius: 4px;
+$elev: 0 2px 8px rgba(0, 0, 0, .12);
+$pad-sm: 0 12px;
+$pad-md: 0 16px;
+$pad-lg: 0 20px;
+$item-h-sm: 32px;
+$item-h-md: 40px;
+$item-h-lg: 48px;
+$gap-icon: 8px;
+$transition: 150ms cubic-bezier(0.2,0,0.38,0.9);
+
+.mb-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.mb-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: $radius;
+  cursor: pointer;
+  font-family: 'IBM Plex Sans', sans-serif;
+  transition: background $transition, color $transition, border-color $transition;
+
+  i { pointer-events: none; }
+
+  &.sm { height: $item-h-sm; padding: $pad-sm; }
+  &.md { height: $item-h-md; padding: $pad-md; }
+  &.lg { height: $item-h-lg; padding: $pad-lg; }
+
+  &.primary { background: $blue-600; color: $neutral-50; }
+  &.secondary { background: $neutral-100; color: $neutral-800; }
+  &.danger { background: $red-800; color: $neutral-50; }
+  &.ghost { background: transparent; color: $neutral-800; }
+
+  &:hover:not(:disabled) { filter: brightness(0.9); }
+  &:active:not(:disabled) { filter: brightness(0.8); }
+  &:focus-visible { outline: 2px solid $blue-600; outline-offset: 2px; }
+  &:disabled { cursor: not-allowed; opacity: .5; }
+}
+
+.mb-combo-wrapper {
+  display: inline-flex;
+  flex-wrap: wrap;
+
+  .mb-trigger {
+    border-radius: 0;
+  }
+  .mb-trigger:first-child {
+    border-top-left-radius: $radius;
+    border-bottom-left-radius: $radius;
+  }
+  .mb-trigger:last-child {
+    border-top-right-radius: $radius;
+    border-bottom-right-radius: $radius;
+    border-left: 1px solid $neutral-200;
+  }
+}
+
+.mb-menu {
+  position: absolute;
+  z-index: 1000;
+  background: $neutral-50;
+  border: 1px solid $neutral-200;
+  box-shadow: $elev;
+  border-radius: $radius;
+  opacity: 0;
+  transform: translateY(4px);
+  animation: fadeIn $transition forwards;
+
+  &.sm .mb-item { height: $item-h-sm; padding: $pad-sm; }
+  &.md .mb-item { height: $item-h-md; padding: $pad-md; }
+  &.lg .mb-item { height: $item-h-lg; padding: $pad-lg; }
+
+  .mb-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+  }
+
+  .mb-item {
+    display: flex;
+    align-items: center;
+    gap: $gap-icon;
+    cursor: pointer;
+    color: $neutral-800;
+    transition: background $transition;
+    white-space: nowrap;
+
+    &:hover:not(.disabled) { background: $neutral-100; }
+    &.disabled { color: $neutral-400; cursor: not-allowed; }
+    &.danger { color: $red-800; }
+    &.danger:hover:not(.disabled) { background: mix($red-800, $neutral-50, 10%); }
+
+    &:focus-visible { outline: 2px solid $blue-600; outline-offset: -2px; }
+
+    .mb-helper { margin-left: auto; }
+  }
+
+  .mb-divider {
+    height: 1px;
+    background: $neutral-200;
+    margin: 4px 0;
+    list-style: none;
+  }
+}
+
+@keyframes fadeIn {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.pos-bottom { top: calc(100% + 4px); }
+.pos-top { bottom: calc(100% + 4px); }
+.pos-left { right: calc(100% + 4px); }
+.pos-right { left: calc(100% + 4px); }
+
+.align-start { left: 0; }
+.align-end { right: 0; }
+
+.mb-menu::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: $neutral-50;
+  border-left: 1px solid $neutral-200;
+  border-top: 1px solid $neutral-200;
+  transform: rotate(45deg);
+}
+.pos-bottom::after { top: -5px; left: 16px; }
+.pos-top::after { bottom: -5px; left: 16px; }
+.pos-left::after { top: 16px; right: -5px; }
+.pos-right::after { top: 16px; left: -5px; }
+
+@media (max-width: 480px) {
+  .mb-menu { width: min(calc(100vw - 24px), 320px); }
+  .mb-combo-wrapper { width: 100%; }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/menu-buttons/menu-buttons.component.ts
@@ -1,0 +1,215 @@
+import { Component, Input, Output, EventEmitter, HostListener, ElementRef, ViewChild, ViewChildren, QueryList } from '@angular/core';
+import { CommonModule, NgClass, NgFor, NgIf } from '@angular/common';
+
+export type MenuButtonsVariant = 'overflow' | 'menu' | 'combo';
+export type MenuButtonsType = 'primary' | 'secondary' | 'danger' | 'ghost';
+export type MenuButtonsSize = 'sm' | 'md' | 'lg';
+export type MenuPlacement = 'top' | 'bottom' | 'left' | 'right' | 'auto';
+
+export interface MenuItem {
+  id: string;
+  label: string;
+  iconLeft?: string;
+  helperText?: string;
+  disabled?: boolean;
+  danger?: boolean;
+  dividerAbove?: boolean;
+}
+
+let uniqueId = 0;
+
+@Component({
+  standalone: true,
+  selector: 'app-menu-buttons',
+  imports: [CommonModule, NgClass, NgFor, NgIf],
+  templateUrl: './menu-buttons.component.html',
+  styleUrls: ['./menu-buttons.component.scss']
+})
+export class MenuButtonsComponent {
+  @Input() variant: MenuButtonsVariant = 'menu';
+  @Input() type: MenuButtonsType = 'primary';
+  @Input() size: MenuButtonsSize = 'md';
+  @Input() label: string = 'Actions';
+  @Input() icon?: string;
+  @Input() disabled = false;
+  @Input() loading = false;
+
+  @Input() items: MenuItem[] = [];
+  @Input() placement: MenuPlacement = 'auto';
+  @Input() align: 'start' | 'end' = 'start';
+  @Input() menuWidth?: number;
+
+  @Input() primaryActionId: string = 'primary';
+  @Output() primaryClick = new EventEmitter<void>();
+
+  @Output() itemSelect = new EventEmitter<MenuItem>();
+  @Output() openChange = new EventEmitter<boolean>();
+
+  open = false;
+  activeIndex = 0;
+  menuId = `mb-menu-${uniqueId++}`;
+
+  placementClass = 'pos-bottom';
+  alignClass = 'align-start';
+
+  @ViewChild('menu') menuRef?: ElementRef<HTMLElement>;
+  @ViewChildren('menuItem') menuItems?: QueryList<ElementRef<HTMLElement>>;
+
+  constructor(private host: ElementRef<HTMLElement>) {}
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: Event) {
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.closeMenu();
+    }
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    if (this.open && this.placement === 'auto') {
+      this.computePlacement();
+    }
+  }
+
+  toggleMenu() {
+    this.open ? this.closeMenu() : this.openMenu();
+  }
+
+  openMenu() {
+    if (this.disabled) {
+      return;
+    }
+    this.open = true;
+    this.openChange.emit(true);
+    setTimeout(() => {
+      this.computePlacement();
+      const first = this.getFirstEnabledIndex();
+      this.focusItem(first);
+    });
+  }
+
+  closeMenu() {
+    if (!this.open) return;
+    this.open = false;
+    this.openChange.emit(false);
+  }
+
+  computePlacement() {
+    if (this.placement !== 'auto') {
+      this.placementClass = `pos-${this.placement}`;
+      this.alignClass = `align-${this.align}`;
+      return;
+    }
+    const hostRect = this.host.nativeElement.getBoundingClientRect();
+    const menu = this.menuRef?.nativeElement;
+    const menuHeight = menu?.offsetHeight || 0;
+    const spaceBottom = window.innerHeight - hostRect.bottom;
+    const spaceTop = hostRect.top;
+    const placeTop = menuHeight > spaceBottom && spaceTop > spaceBottom;
+    this.placementClass = placeTop ? 'pos-top' : 'pos-bottom';
+    this.alignClass = `align-${this.align}`;
+  }
+
+  onPrimaryClick() {
+    if (this.disabled) return;
+    this.primaryClick.emit();
+  }
+
+  onTriggerKeydown(event: KeyboardEvent) {
+    if (this.disabled) return;
+    const key = event.key;
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      this.toggleMenu();
+    } else if (key === 'ArrowDown') {
+      event.preventDefault();
+      if (!this.open) {
+        this.openMenu();
+      } else {
+        const next = this.getNextEnabledIndex(this.activeIndex);
+        this.focusItem(next);
+      }
+    } else if (key === 'ArrowUp') {
+      event.preventDefault();
+      if (!this.open) {
+        this.openMenu();
+      } else {
+        const prev = this.getPrevEnabledIndex(this.activeIndex);
+        this.focusItem(prev);
+      }
+    }
+  }
+
+  onItemKeydown(event: KeyboardEvent, index: number) {
+    const key = event.key;
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      const next = this.getNextEnabledIndex(index);
+      this.focusItem(next);
+    } else if (key === 'ArrowUp') {
+      event.preventDefault();
+      const prev = this.getPrevEnabledIndex(index);
+      this.focusItem(prev);
+    } else if (key === 'Home') {
+      event.preventDefault();
+      this.focusItem(this.getFirstEnabledIndex());
+    } else if (key === 'End') {
+      event.preventDefault();
+      this.focusItem(this.getLastEnabledIndex());
+    } else if (key === 'Escape') {
+      event.preventDefault();
+      this.closeMenu();
+    } else if (key === 'Tab') {
+      this.closeMenu();
+    } else if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      const item = this.items[index];
+      this.selectItem(item);
+    }
+  }
+
+  onItemClick(item: MenuItem) {
+    if (item.disabled) return;
+    this.selectItem(item);
+  }
+
+  selectItem(item: MenuItem) {
+    this.itemSelect.emit(item);
+    this.closeMenu();
+  }
+
+  focusItem(index: number) {
+    if (index < 0) return;
+    this.activeIndex = index;
+    setTimeout(() => {
+      const el = this.menuItems?.toArray()[index]?.nativeElement;
+      el?.focus();
+    });
+  }
+
+  getFirstEnabledIndex(): number {
+    return this.items.findIndex(it => !it.disabled);
+  }
+
+  getLastEnabledIndex(): number {
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      if (!this.items[i].disabled) return i;
+    }
+    return 0;
+  }
+
+  getNextEnabledIndex(current: number): number {
+    for (let i = current + 1; i < this.items.length; i++) {
+      if (!this.items[i].disabled) return i;
+    }
+    return this.getFirstEnabledIndex();
+  }
+
+  getPrevEnabledIndex(current: number): number {
+    for (let i = current - 1; i >= 0; i--) {
+      if (!this.items[i].disabled) return i;
+    }
+    return this.getLastEnabledIndex();
+  }
+}
+

--- a/frontend/agentes-frontend/src/stories/componentes/menu-buttons/menu-buttons.stories.ts
+++ b/frontend/agentes-frontend/src/stories/componentes/menu-buttons/menu-buttons.stories.ts
@@ -1,0 +1,125 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { MenuButtonsComponent, MenuItem } from '../../../app/shared/components/menu-buttons/menu-buttons.component';
+
+const VARIANTS = ['overflow', 'menu', 'combo'] as const;
+const TYPES = ['primary', 'secondary', 'danger', 'ghost'] as const;
+const SIZES = ['sm', 'md', 'lg'] as const;
+const PLACEMENTS = ['top', 'bottom', 'left', 'right', 'auto'] as const;
+
+const meta: Meta<MenuButtonsComponent> = {
+  title: 'Shared/Components/MenuButtons',
+  component: MenuButtonsComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, MenuButtonsComponent],
+    }),
+  ],
+  argTypes: {
+    variant: { control: 'select', options: VARIANTS as unknown as string[] },
+    type: { control: 'select', options: TYPES as unknown as string[] },
+    size: { control: 'select', options: SIZES as unknown as string[] },
+    label: { control: 'text' },
+    icon: { control: 'text' },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    placement: { control: 'select', options: PLACEMENTS as unknown as string[] },
+    align: { control: 'select', options: ['start', 'end'] },
+    items: { control: 'object' },
+    primaryClick: { action: 'primaryClick' },
+    itemSelect: { action: 'itemSelect' },
+    openChange: { action: 'openChange' },
+  },
+  args: {
+    variant: 'menu',
+    type: 'primary',
+    size: 'md',
+    label: 'Actions',
+    icon: 'fa fa-ellipsis-v',
+    disabled: false,
+    loading: false,
+    placement: 'auto',
+    align: 'start',
+    items: [],
+  },
+};
+export default meta;
+
+type Story = StoryObj<MenuButtonsComponent>;
+
+const MENU_ITEMS: MenuItem[] = [
+  { id: 'open', label: 'Open', iconLeft: 'fa fa-folder-open' },
+  { id: 'save', label: 'Save as...', iconLeft: 'fa fa-save' },
+  {
+    id: 'delete',
+    label: 'Delete',
+    iconLeft: 'fa fa-trash',
+    helperText: 'Del',
+    danger: true,
+    dividerAbove: true,
+  },
+];
+
+export const OverflowAllPlacements: Story = {
+  render: (args) => ({
+    props: { ...args, items: MENU_ITEMS },
+    template: `
+      <div style="display:flex;flex-wrap:wrap;gap:16px;">
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="bottom" align="start" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="bottom" align="end" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="top" align="start" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="top" align="end" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="left" align="start" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="left" align="end" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="right" align="start" [items]="items"></app-menu-buttons>
+        <app-menu-buttons variant="overflow" icon="fa fa-ellipsis-v" placement="right" align="end" [items]="items"></app-menu-buttons>
+      </div>
+    `,
+  }),
+};
+
+export const MenuDefault: Story = {
+  args: {
+    variant: 'menu',
+    type: 'primary',
+    label: 'Actions',
+    items: MENU_ITEMS,
+  },
+};
+
+export const ComboDefault: Story = {
+  args: {
+    variant: 'combo',
+    type: 'primary',
+    label: 'Primary action',
+    items: MENU_ITEMS,
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => ({
+    props: { ...args, items: MENU_ITEMS },
+    template: `
+      <div style="display:flex;gap:16px;align-items:center;">
+        <app-menu-buttons size="sm" variant="menu" label="Small" [items]="items"></app-menu-buttons>
+        <app-menu-buttons size="md" variant="menu" label="Medium" [items]="items"></app-menu-buttons>
+        <app-menu-buttons size="lg" variant="menu" label="Large" [items]="items"></app-menu-buttons>
+      </div>
+    `,
+  }),
+};
+
+export const Types: Story = {
+  render: (args) => ({
+    props: { ...args, items: MENU_ITEMS },
+    template: `
+      <div style="display:flex;gap:16px;flex-wrap:wrap;">
+        <app-menu-buttons type="primary" variant="menu" label="Primary" [items]="items"></app-menu-buttons>
+        <app-menu-buttons type="secondary" variant="menu" label="Secondary" [items]="items"></app-menu-buttons>
+        <app-menu-buttons type="danger" variant="menu" label="Danger" [items]="items"></app-menu-buttons>
+        <app-menu-buttons type="ghost" variant="menu" label="Ghost" [items]="items"></app-menu-buttons>
+      </div>
+    `,
+  }),
+};
+


### PR DESCRIPTION
## Summary
- add standalone MenuButtons component with overflow, menu, and combo variants
- include SCSS styles and responsive behavior
- add Storybook stories demonstrating placements, sizes, and types

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bad3e61d2c8331bd2d6d15acea63a3