### PR TITLE
feat: add Carbon menu components

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.html
@@ -1,0 +1,28 @@
+<ng-container [ngSwitch]="item.role">
+  <hr *ngSwitchCase="'separator'" class="menu-divider" role="separator" />
+  <button
+    #button
+    *ngSwitchDefault
+    type="button"
+    class="menu-item"
+    [ngClass]="{
+      active: active,
+      selected: item.selected || item.checked,
+      danger: item.danger,
+      disabled: item.disabled
+    }"
+    [attr.role]="item.role || 'menuitem'"
+    [attr.aria-disabled]="item.disabled"
+    [attr.aria-checked]="item.role === 'menuitemcheckbox' || item.role === 'menuitemradio' ? item.checked : null"
+    [attr.aria-selected]="item.role === 'menuitem' ? item.selected : null"
+    [attr.aria-label]="item.ariaLabel || null"
+    tabindex="-1"
+    (click)="onClick($event)"
+  >
+    <span class="label">{{ item.label }}</span>
+    <span class="suffix">
+      <span *ngIf="item.shortcut" class="shortcut">{{ item.shortcut }}</span>
+      <i *ngIf="item.trailingIcon" class="{{ item.trailingIcon }}" aria-hidden="true"></i>
+    </span>
+  </button>
+</ng-container>

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.scss
@@ -1,0 +1,83 @@
+@import "../../general/colors/colors.scss";
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 16px;
+  height: 40px;
+  background: $neutral-50;
+  border: none;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  color: $neutral-800;
+  cursor: pointer;
+  transition: background 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+    color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+
+  .suffix {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: $neutral-600;
+  }
+
+  &.danger {
+    color: $red-700;
+    .suffix {
+      color: inherit;
+    }
+  }
+
+  &.disabled {
+    color: $neutral-400;
+    cursor: not-allowed;
+    background: $neutral-50;
+    .suffix {
+      color: $neutral-400;
+    }
+  }
+
+  &:hover:not(.disabled) {
+    background: $neutral-100;
+  }
+
+  &.active:not(.disabled),
+  &:focus-visible {
+    outline: 2px solid $blue-600;
+    outline-offset: -2px;
+  }
+
+  &:active:not(.disabled) {
+    background: $neutral-200;
+  }
+
+  &.selected:not(.disabled) {
+    background: $red-600;
+    color: $neutral-0;
+    .suffix {
+      color: $neutral-0;
+    }
+  }
+
+  &.danger:hover:not(.disabled) {
+    background: $red-50;
+  }
+
+  &.danger:active:not(.disabled) {
+    background: $red-100;
+  }
+
+  &.danger.selected:not(.disabled) {
+    background: $red-600;
+    color: $neutral-0;
+  }
+}
+
+.menu-divider {
+  border: none;
+  border-top: 1px solid $neutral-200;
+  margin: 4px 0;
+}

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu-item.component.ts
@@ -1,0 +1,31 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, EventEmitter, Input, Output, ViewChild, ElementRef } from '@angular/core';
+import { MenuItem, MenuSelectable } from './menu.types';
+
+@Component({
+  selector: 'app-menu-item',
+  standalone: true,
+  imports: [CommonModule, NgClass],
+  templateUrl: './menu-item.component.html',
+  styleUrls: ['./menu-item.component.scss']
+})
+export class MenuItemComponent {
+  @Input() item!: MenuItem;
+  @Input() active = false;
+  @Input() selectable: MenuSelectable = 'none';
+  @Output() pressed = new EventEmitter<MenuItem>();
+
+  @ViewChild('button', { static: false }) buttonRef?: ElementRef<HTMLButtonElement>;
+
+  onClick(event: Event) {
+    event.stopPropagation();
+    if (this.item.disabled || this.item.role === 'separator') {
+      return;
+    }
+    this.pressed.emit(this.item);
+  }
+
+  focus() {
+    this.buttonRef?.nativeElement.focus();
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.html
@@ -1,0 +1,20 @@
+<div
+  class="menu"
+  role="menu"
+  aria-orientation="vertical"
+  [attr.aria-label]="ariaLabel"
+  tabindex="0"
+  (keydown)="onKeydown($event)"
+>
+  <ul class="menu-list" [style.--max-height.px]="maxHeight">
+    <li *ngFor="let item of items; let i = index; trackBy: trackById">
+      <hr *ngIf="item.dividerAbove" class="menu-divider" role="separator" />
+      <app-menu-item
+        [item]="item"
+        [active]="i === activeIndex"
+        [selectable]="selectable"
+        (pressed)="onItemPressed(item)"
+      ></app-menu-item>
+    </li>
+  </ul>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.scss
@@ -1,0 +1,31 @@
+@import "../../general/colors/colors.scss";
+
+.menu {
+  background: $neutral-0;
+  border: 1px solid $neutral-200;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+  width: 240px;
+}
+
+.menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  max-height: var(--max-height);
+  overflow-y: auto;
+  box-shadow: inset 0 -8px 8px -8px rgba(0, 0, 0, 0.12);
+}
+
+.menu-divider {
+  border: none;
+  border-top: 1px solid $neutral-200;
+  margin: 4px 0;
+}
+
+@media (max-width: 480px) {
+  .menu {
+    width: 100%;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu.component.ts
@@ -1,0 +1,182 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ViewChildren,
+  QueryList,
+  AfterViewInit
+} from '@angular/core';
+import { CommonModule, NgClass } from '@angular/common';
+import { MenuItem, MenuSelectable } from './menu.types';
+import { MenuItemComponent } from './menu-item.component';
+
+@Component({
+  selector: 'app-menu',
+  standalone: true,
+  imports: [CommonModule, NgClass, MenuItemComponent],
+  templateUrl: './menu.component.html',
+  styleUrls: ['./menu.component.scss']
+})
+export class MenuComponent implements AfterViewInit {
+  @Input() items: MenuItem[] = [];
+  @Input() selectable: MenuSelectable = 'none';
+  @Input() ariaLabel = 'Menu';
+  @Input() maxHeight = 320;
+
+  @Output() action = new EventEmitter<MenuItem>();
+  @Output() closed = new EventEmitter<void>();
+
+  @ViewChildren(MenuItemComponent) itemCmps!: QueryList<MenuItemComponent>;
+
+  activeIndex = -1;
+  private typeaheadBuffer = '';
+  private typeaheadTimeout: any;
+
+  ngAfterViewInit() {
+    this.activeIndex = this.getFirstEnabledIndex();
+    this.focusCurrent();
+  }
+
+  trackById(_index: number, item: MenuItem) {
+    return item.id;
+  }
+
+  onItemPressed(item: MenuItem) {
+    this.applySelection(item);
+    this.action.emit(item);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        event.preventDefault();
+        this.setActiveIndex(this.getNextIndex(this.activeIndex));
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        event.preventDefault();
+        this.setActiveIndex(this.getPrevIndex(this.activeIndex));
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.setActiveIndex(this.getFirstEnabledIndex());
+        break;
+      case 'End':
+        event.preventDefault();
+        this.setActiveIndex(this.getLastEnabledIndex());
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        if (this.activeIndex > -1) {
+          const item = this.items[this.activeIndex];
+          if (!this.isDisabled(item)) {
+            this.onItemPressed(item);
+          }
+        }
+        break;
+      case 'Escape':
+        this.closed.emit();
+        break;
+      default:
+        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          this.handleTypeahead(event.key);
+        }
+        break;
+    }
+  }
+
+  private handleTypeahead(char: string) {
+    this.typeaheadBuffer += char.toLowerCase();
+    clearTimeout(this.typeaheadTimeout);
+    const idx = this.items.findIndex((item, i) =>
+      !this.isDisabled(item) &&
+      item.label?.toLowerCase().startsWith(this.typeaheadBuffer)
+    );
+    if (idx !== -1) {
+      this.setActiveIndex(idx);
+    }
+    this.typeaheadTimeout = setTimeout(() => {
+      this.typeaheadBuffer = '';
+    }, 350);
+  }
+
+  private setActiveIndex(index: number) {
+    if (index === -1) return;
+    this.activeIndex = index;
+    this.focusCurrent();
+  }
+
+  private focusCurrent() {
+    if (this.activeIndex > -1) {
+      const cmp = this.itemCmps.get(this.activeIndex);
+      cmp?.focus();
+      const el = cmp?.buttonRef?.nativeElement;
+      el?.scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  private getNextIndex(current: number): number {
+    let idx = current;
+    do {
+      idx = (idx + 1) % this.items.length;
+    } while (this.isDisabled(this.items[idx]) && idx !== current);
+    return idx;
+  }
+
+  private getPrevIndex(current: number): number {
+    let idx = current;
+    do {
+      idx = (idx - 1 + this.items.length) % this.items.length;
+    } while (this.isDisabled(this.items[idx]) && idx !== current);
+    return idx;
+  }
+
+  private getFirstEnabledIndex(): number {
+    return this.items.findIndex(item => !this.isDisabled(item));
+  }
+
+  private getLastEnabledIndex(): number {
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      if (!this.isDisabled(this.items[i])) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private isDisabled(item: MenuItem | undefined): boolean {
+    return !item || item.disabled || item.role === 'separator';
+  }
+
+  private applySelection(item: MenuItem) {
+    if (this.selectable === 'none') {
+      return;
+    }
+
+    if (item.role === 'menuitemcheckbox') {
+      if (this.selectable === 'single') {
+        this.items.forEach(i => (i.checked = false));
+        item.checked = true;
+      } else {
+        item.checked = !item.checked;
+      }
+    } else if (item.role === 'menuitemradio') {
+      this.items.forEach(i => {
+        if (i.role === 'menuitemradio') {
+          i.checked = false;
+        }
+      });
+      item.checked = true;
+    } else {
+      if (this.selectable === 'single') {
+        this.items.forEach(i => (i.selected = false));
+        item.selected = true;
+      } else {
+        item.selected = !item.selected;
+      }
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/menu/menu.types.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/menu/menu.types.ts
@@ -1,0 +1,15 @@
+export type MenuSelectable = 'none' | 'single' | 'multiple';
+
+export interface MenuItem {
+  id: string;
+  label?: string;
+  shortcut?: string;       // ex: '⌘X' ou 'Ctrl+X'
+  trailingIcon?: string;   // ex: 'fa-regular fa-envelope'
+  disabled?: boolean;
+  danger?: boolean;        // item destrutivo
+  selected?: boolean;
+  checked?: boolean;       // para checkbox/radio
+  role?: 'menuitem' | 'menuitemcheckbox' | 'menuitemradio' | 'separator';
+  dividerAbove?: boolean;  // adiciona separador acima
+  ariaLabel?: string;
+}


### PR DESCRIPTION
## Summary
- implement standalone `MenuComponent` and `MenuItemComponent` replicating Carbon menu behaviors
- add SCSS styles mirroring Carbon states and responsiveness
- define menu item typing for shortcuts, icons and selection control

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68bec43699b48331adeaa6b84628d9bf