### PR TITLE
feat: add modal component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/modal/README.md
+++ b/frontend/agentes-frontend/src/app/shared/components/modal/README.md
@@ -1,0 +1,77 @@
+# Modal
+
+Componente Modal standalone inspirado no Carbon Design System.
+
+## API
+
+### Inputs
+- `open: boolean` – controla a visibilidade do modal.
+- `size: 'sm' | 'md' | 'lg' | 'xl'` – tamanho do modal (padrão `lg`).
+- `title: string` – título exibido no cabeçalho.
+- `label?: string` – label opcional acima do título.
+- `description?: string` – texto curto abaixo do cabeçalho.
+- `showClose: boolean` – exibe botão de fechar no cabeçalho.
+- `closeOnEsc: boolean`
+- `closeOnBackdrop: boolean`
+- `focusTrap: boolean`
+- `initialFocus?: string` – seletor CSS do elemento que recebe foco ao abrir.
+- `actions: ModalAction[]` – botões do rodapé.
+- `busy: boolean` – estado de carregamento.
+- `busyMessage: string`
+- `steps: ModalStep[]` – exibe stepper no cabeçalho.
+- `ariaLabel`, `ariaLabelledby`, `ariaDescribedby` – atributos de acessibilidade opcionais.
+
+### Outputs
+- `openChange: EventEmitter<boolean>` – usado para two-way binding `[(open)]`.
+- `closed: EventEmitter<'esc' | 'backdrop' | 'close-button' | 'action'>` – razão do fechamento.
+- `action: EventEmitter<string>` – id da ação clicada.
+
+### Tipos
+```ts
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ModalActionKind = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'ghost' | 'cancel';
+
+export interface ModalAction {
+  id: string;
+  label: string;
+  kind: ModalActionKind;
+  align?: 'left' | 'right';
+  disabled?: boolean;
+}
+
+export interface ModalStep {
+  label: string;
+  optionalLabel?: string;
+  state: 'complete' | 'current' | 'incomplete';
+}
+```
+
+## Exemplo
+```html
+<button (click)="open = true" #trigger>Open</button>
+
+<app-modal
+  [(open)]="open"
+  size="lg"
+  [label]="'Optional label'"
+  title="Title"
+  [description]="'Lorem ipsum dolor sit amet…'"
+  [steps]="[
+    { label:'Step', optionalLabel:'Optional label', state:'current' },
+    { label:'Step', optionalLabel:'Optional label', state:'incomplete' },
+    { label:'Step', optionalLabel:'Optional label', state:'incomplete' }
+  ]"
+  [actions]="[
+    { id:'cancel', label:'Cancel', kind:'ghost', align:'left' },
+    { id:'secondary', label:'Button', kind:'secondary' },
+    { id:'primary', label:'Button', kind:'primary' }
+  ]"
+  [busy]="isSaving"
+  busyMessage="Loading message"
+  (action)="onAction($event)"
+  (closed)="onClosed($event)">
+  <div modal-body>
+    <!-- Conteúdo arbitrário -->
+  </div>
+</app-modal>
+```

--- a/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.html
@@ -1,0 +1,55 @@
+<div class="modal-backdrop" *ngIf="open" (click)="onBackdropClick()"></div>
+<div class="modal-wrapper" *ngIf="open">
+  <div #container class="modal-container" [ngClass]="size" role="dialog" aria-modal="true"
+       [attr.aria-label]="ariaLabel"
+       [attr.aria-labelledby]="ariaLabelledby ? ariaLabelledby : titleId"
+       [attr.aria-describedby]="ariaDescribedby ? ariaDescribedby : descId"
+       [cdkTrapFocus]="focusTrap" [cdkTrapFocusAutoCapture]="focusTrap">
+    <div class="modal-header">
+      <p class="modal-label" *ngIf="label">{{ label }}</p>
+      <div class="modal-title-row">
+        <h2 [id]="titleId">{{ title }}</h2>
+        <button type="button" class="close-button" aria-label="Fechar" *ngIf="showClose" (click)="onCloseButton()">
+          &times;
+        </button>
+      </div>
+      <div class="modal-steps" *ngIf="steps.length">
+        <div class="step-bar">
+          <div class="step-bar-fill" [style.width.%]="progress"></div>
+        </div>
+        <ul class="step-items">
+          <li *ngFor="let step of steps" [ngClass]="step.state">
+            <span class="step-label">{{ step.label }}</span>
+            <span class="step-optional" *ngIf="step.optionalLabel">{{ step.optionalLabel }}</span>
+          </li>
+        </ul>
+      </div>
+      <p class="modal-description" *ngIf="description" [id]="descId">{{ description }}</p>
+    </div>
+    <div class="modal-body">
+      <ng-content select="[modal-body]"></ng-content>
+    </div>
+    <div class="modal-footer">
+      <div class="left-actions">
+        <ng-container *ngFor="let act of leftActions">
+          <button class="modal-action" [ngClass]="act.kind" [disabled]="busy || act.disabled"
+            (click)="onActionClick(act)" [attr.aria-disabled]="(busy || act.disabled) ? true : null">
+            {{ act.label }}
+          </button>
+        </ng-container>
+      </div>
+      <div class="right-actions" *ngIf="!busy">
+        <ng-container *ngFor="let act of rightActions">
+          <button class="modal-action" [ngClass]="act.kind" [disabled]="busy || act.disabled"
+            (click)="onActionClick(act)" [attr.aria-disabled]="(busy || act.disabled) ? true : null">
+            {{ act.label }}
+          </button>
+        </ng-container>
+      </div>
+      <div class="busy-state" *ngIf="busy">
+        <div class="spinner"></div>
+        <span>{{ busyMessage }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.scss
@@ -1,0 +1,226 @@
+@import "../../general/colors/colors.scss";
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba($neutral-950, .64);
+  animation: fade 150ms cubic-bezier(0.2,0,0.38,0.9) forwards;
+}
+
+.modal-wrapper {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.modal-container {
+  background: $neutral-0;
+  border: 1px solid $neutral-200;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.2);
+  width: 100%;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  animation: scaleFade 150ms cubic-bezier(0.2,0,0.38,0.9) forwards;
+}
+
+.modal-container.sm { max-width: 416px; }
+.modal-container.md { max-width: 672px; }
+.modal-container.lg { max-width: 832px; }
+.modal-container.xl { max-width: 1056px; }
+
+.modal-header {
+  padding: 24px;
+}
+
+.modal-label {
+  color: $neutral-600;
+  font-size: 0.75rem;
+  margin: 0 0 4px 0;
+}
+
+.modal-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+
+  h2 {
+    margin: 0;
+    font-weight: 600;
+    font-size: 1.25rem;
+    flex: 1;
+  }
+}
+
+.close-button {
+  background: transparent;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: $neutral-600;
+  font-size: 1.25rem;
+  transition: background-color 150ms cubic-bezier(0.2,0,0.38,0.9);
+}
+
+.close-button:hover {
+  background: $neutral-100;
+}
+
+.close-button:focus {
+  outline: 2px solid $blue-600;
+  outline-offset: 2px;
+}
+
+.modal-description {
+  margin-top: 0.5rem;
+}
+
+.modal-steps {
+  margin-top: 1rem;
+
+  .step-bar {
+    height: 2px;
+    background: $neutral-200;
+    position: relative;
+    overflow: hidden;
+    .step-bar-fill {
+      height: 2px;
+      background: $red-600;
+      width: 0;
+      transition: width 150ms cubic-bezier(0.2,0,0.38,0.9);
+    }
+  }
+
+  .step-items {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0.5rem 0 0 0;
+    padding: 0;
+
+    li {
+      font-size: 0.75rem;
+      color: $neutral-600;
+      display: flex;
+      flex-direction: column;
+    }
+
+    li.complete .step-label,
+    li.current .step-label {
+      color: $neutral-900;
+    }
+  }
+}
+
+.modal-body {
+  padding: 16px 24px;
+  flex: 1;
+  overflow: auto;
+}
+
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid $neutral-200;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.left-actions, .right-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.modal-action {
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  border-radius: 4px;
+  transition: background-color 150ms cubic-bezier(0.2,0,0.38,0.9), color 150ms cubic-bezier(0.2,0,0.38,0.9);
+}
+
+.modal-action:focus {
+  outline: 2px solid $blue-600;
+  outline-offset: 2px;
+}
+
+.modal-action.primary {
+  background: $red-600;
+  color: $neutral-0;
+}
+.modal-action.primary:hover:not(:disabled) { background: $red-700; }
+.modal-action.primary:active:not(:disabled) { background: $red-800; }
+
+.modal-action.secondary {
+  background: $neutral-800;
+  color: $neutral-0;
+}
+.modal-action.secondary:hover:not(:disabled) { background: $neutral-700; }
+.modal-action.secondary:active:not(:disabled) { background: $neutral-900; }
+
+.modal-action.danger {
+  background: $red-700;
+  color: $neutral-0;
+}
+.modal-action.danger:hover:not(:disabled) { background: $red-800; }
+.modal-action.danger:active:not(:disabled) { background: $red-900; }
+
+.modal-action.ghost {
+  background: transparent;
+  color: $red-600;
+}
+.modal-action.ghost:hover:not(:disabled) { background: $red-50; }
+.modal-action.ghost:active:not(:disabled) { background: $red-100; }
+
+.modal-action:disabled {
+  background: $neutral-300;
+  color: $neutral-600;
+  cursor: not-allowed;
+}
+
+.busy-state {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: $neutral-600;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid $neutral-300;
+  border-top-color: $red-600;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scaleFade {
+  from { opacity: 0; transform: scale(.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (max-width: 480px) {
+  .modal-wrapper { padding: 0; }
+  .modal-container { width: 100%; height: 100%; border-radius: 0; }
+  .modal-footer { flex-direction: column; align-items: stretch; }
+  .right-actions, .left-actions { width: 100%; justify-content: flex-end; }
+  .left-actions { order: -1; justify-content: flex-start; }
+  .modal-action { width: 100%; }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/modal/modal.component.ts
@@ -1,0 +1,167 @@
+import { A11yModule } from '@angular/cdk/a11y';
+import { CommonModule, NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
+import { Component, ElementRef, EventEmitter, HostListener, Input, OnDestroy, Output, ViewChild } from '@angular/core';
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ModalActionKind = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'ghost' | 'cancel';
+
+export interface ModalStep {
+  label: string;
+  optionalLabel?: string;
+  state: 'complete' | 'current' | 'incomplete';
+}
+
+export interface ModalAction {
+  id: string;
+  label: string;
+  kind: ModalActionKind;
+  align?: 'left' | 'right';
+  disabled?: boolean;
+}
+
+@Component({
+  selector: 'app-modal',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgIf, NgTemplateOutlet, A11yModule],
+  templateUrl: './modal.component.html',
+  styleUrls: ['./modal.component.scss']
+})
+export class ModalComponent implements OnDestroy {
+  private _open = false;
+  private lastActiveElement: HTMLElement | null = null;
+  private bodyOverflow = '';
+
+  @ViewChild('container') containerRef!: ElementRef<HTMLElement>;
+
+  @Input()
+  get open(): boolean { return this._open; }
+  set open(value: boolean) {
+    this._open = value;
+    if (value) {
+      this.onOpen();
+    } else {
+      this.onClose();
+    }
+  }
+
+  @Input() size: ModalSize = 'lg';
+  @Input() title = '';
+  @Input() label?: string;
+  @Input() description?: string;
+  @Input() showClose = true;
+  @Input() closeOnEsc = true;
+  @Input() closeOnBackdrop = true;
+  @Input() focusTrap = true;
+  @Input() initialFocus?: string;
+  @Input() actions: ModalAction[] = [];
+  @Input() busy = false;
+  @Input() busyMessage = 'Loading message';
+  @Input() steps: ModalStep[] = [];
+
+  // A11y
+  @Input() ariaLabel?: string;
+  @Input() ariaLabelledby?: string;
+  @Input() ariaDescribedby?: string;
+
+  @Output() openChange = new EventEmitter<boolean>();
+  @Output() closed = new EventEmitter<'esc' | 'backdrop' | 'close-button' | 'action'>();
+  @Output() action = new EventEmitter<string>();
+
+  titleId = `modal-title-${Math.random().toString(36).substring(2,9)}`;
+  descId = `modal-desc-${Math.random().toString(36).substring(2,9)}`;
+
+  ngOnDestroy(): void {
+    if (this.open) {
+      this.restoreBody();
+    }
+  }
+
+  get leftActions(): ModalAction[] {
+    return this.actions.filter(a => a.align === 'left');
+  }
+
+  get rightActions(): ModalAction[] {
+    return this.actions.filter(a => a.align !== 'left');
+  }
+
+  get progress(): number {
+    if (!this.steps.length) return 0;
+    const completed = this.steps.filter(s => s.state === 'complete').length;
+    const currentIndex = this.steps.findIndex(s => s.state === 'current');
+    const value = completed + (currentIndex >= 0 ? 1 : 0);
+    return (value / this.steps.length) * 100;
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  handleEsc(event: KeyboardEvent): void {
+    if (this.open && this.closeOnEsc && !this.busy) {
+      event.preventDefault();
+      this.emitClose('esc');
+    }
+  }
+
+  onBackdropClick(): void {
+    if (this.closeOnBackdrop && !this.busy) {
+      this.emitClose('backdrop');
+    }
+  }
+
+  onCloseButton(): void {
+    if (!this.busy) {
+      this.emitClose('close-button');
+    }
+  }
+
+  onActionClick(act: ModalAction): void {
+    if (act.disabled || this.busy) {
+      return;
+    }
+    this.action.emit(act.id);
+    if (act.kind === 'cancel') {
+      this.emitClose('action');
+    }
+  }
+
+  private onOpen(): void {
+    this.lastActiveElement = document.activeElement as HTMLElement;
+    this.bodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    setTimeout(() => this.setInitialFocus(), 0);
+  }
+
+  private onClose(): void {
+    this.restoreBody();
+    if (this.lastActiveElement) {
+      this.lastActiveElement.focus();
+    }
+  }
+
+  private restoreBody(): void {
+    document.body.style.overflow = this.bodyOverflow;
+  }
+
+  private setInitialFocus(): void {
+    if (!this.open) return;
+    const container = this.containerRef?.nativeElement;
+    let focusEl: HTMLElement | null = null;
+    if (this.initialFocus) {
+      focusEl = container.querySelector(this.initialFocus) as HTMLElement;
+    }
+    if (!focusEl) {
+      focusEl = container.querySelector('button.modal-action.primary') as HTMLElement;
+    }
+    if (!focusEl) {
+      focusEl = container;
+    }
+    focusEl.focus();
+  }
+
+  private emitClose(reason: 'esc' | 'backdrop' | 'close-button' | 'action'): void {
+    this._open = false;
+    this.openChange.emit(false);
+    this.closed.emit(reason);
+    this.onClose();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add standalone modal component with Carbon-inspired design
- document modal API and usage

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c01ea48f1883319cccfb8c3bda78f4