### PR TITLE
feat: add notification components

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.html
@@ -1,0 +1,46 @@
+<div
+  class="notification-item"
+  [@fadeSlide]
+  [ngClass]="[
+    item.kind,
+    'type-' + item.type,
+    item.title ? 'has-title' : '',
+    item.actionLabel ? 'has-action' : '',
+    item.timestamp ? 'has-timestamp' : '',
+    item.theme ? 'theme-' + item.theme : ''
+  ]"
+  [attr.role]="item.type === 'warning' || item.type === 'error' ? 'alert' : 'status'"
+  aria-live="polite"
+  aria-atomic="true"
+  tabindex="0"
+>
+  <span class="notification-icon" [ngClass]="iconClass(item.type)" aria-hidden="true"></span>
+  <div class="notification-content">
+    <div *ngIf="item.title" class="notification-title">{{ item.title }}</div>
+    <div class="notification-message">{{ item.message }}</div>
+    <div *ngIf="item.timestamp" class="notification-timestamp">{{ item.timestamp }}</div>
+  </div>
+  <div class="notification-actions">
+    <button
+      *ngIf="item.actionLabel"
+      type="button"
+      class="notification-action"
+      [ngClass]="item.actionStyle || 'link'"
+      (click)="onAction()"
+      (keydown.enter)="onAction()"
+      (keydown.space)="onAction()"
+      [attr.aria-label]="item.actionAriaLabel || item.actionLabel"
+    >
+      {{ item.actionLabel }}
+    </button>
+    <button
+      *ngIf="item.dismissible !== false"
+      type="button"
+      class="notification-close"
+      aria-label="Fechar"
+      (click)="onDismiss()"
+    >
+      <span aria-hidden="true" class="fa-solid fa-xmark"></span>
+    </button>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.scss
@@ -1,0 +1,127 @@
+@import "../../general/colors/colors.scss";
+
+.notification-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  padding: 12px 16px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  border-left: 4px solid transparent;
+  transition: background 150ms cubic-bezier(0.2,0,0.38,0.9),
+    color 150ms cubic-bezier(0.2,0,0.38,0.9),
+    box-shadow 150ms cubic-bezier(0.2,0,0.38,0.9);
+
+  .notification-icon { font-size: 20px; }
+
+  .notification-content { flex: 1; min-width: 0; }
+  .notification-title { font-weight: 600; margin-bottom: 2px; }
+  .notification-timestamp { font-size: 12px; margin-top: 4px; }
+
+  .notification-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+  }
+
+  .notification-action {
+    cursor: pointer;
+    background: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: $blue-600;
+    transition: background 150ms cubic-bezier(0.2,0,0.38,0.9),
+      color 150ms cubic-bezier(0.2,0,0.38,0.9),
+      border-color 150ms cubic-bezier(0.2,0,0.38,0.9);
+
+    &.link {
+      text-decoration: none;
+      &:hover { text-decoration: underline; }
+      &:disabled { color: $neutral-500; cursor: default; }
+    }
+
+    &.outline {
+      border: 1px solid $blue-600;
+      border-radius: 4px;
+      padding: 2px 8px;
+      &:hover { background: $blue-50; }
+      &:disabled { border-color: $neutral-400; color: $neutral-500; }
+    }
+
+    &.ghost {
+      border-radius: 4px;
+      padding: 2px 8px;
+      &:hover { background: $neutral-200; }
+      &:disabled { color: $neutral-500; }
+    }
+
+    &:focus-visible {
+      outline: 2px solid $blue-600;
+      outline-offset: 2px;
+    }
+
+    &:active { filter: brightness(0.95); }
+  }
+
+  .notification-close {
+    background: none;
+    border: 0;
+    cursor: pointer;
+    color: inherit;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover { opacity: 0.8; }
+
+    &:focus-visible {
+      outline: 2px solid $blue-600;
+      outline-offset: 2px;
+    }
+  }
+
+  &.toast {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    border-radius: 6px;
+  }
+}
+
+@mixin type-variant($color, $bg, $border, $text) {
+  border-left-color: $color;
+  &.theme-light,
+  .theme-light & {
+    background: $bg;
+    border-color: $border;
+    color: $text;
+    .notification-title { color: $text; }
+    .notification-icon { color: $color; }
+  }
+  &.theme-dark,
+  .theme-dark & {
+    background: $neutral-800;
+    border-color: $neutral-700;
+    color: $neutral-100;
+    .notification-title { color: $neutral-100; }
+    .notification-icon { color: $color; }
+    .notification-timestamp { color: $neutral-200; }
+    .notification-action.ghost:hover { background: $neutral-700; }
+  }
+}
+
+.notification-item.type-info    { @include type-variant($blue-600, $blue-50, $blue-200, $blue-800); }
+.notification-item.type-success { @include type-variant($green-600, $green-50, $green-200, $green-800); }
+.notification-item.type-warning { @include type-variant($yellow-600, $yellow-50, $yellow-200, $yellow-800); }
+.notification-item.type-error   { @include type-variant($red-600, $red-50, $red-200, $red-800); }
+
+@media (max-width: 480px) {
+  .notification-item {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    .notification-content { flex-basis: 100%; }
+    .notification-actions { width: 100%; justify-content: flex-end; margin-left: 0; }
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/notification-item/notification-item.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
+
+export type NotificationKind = 'inline' | 'toast';
+export type NotificationType = 'info' | 'success' | 'warning' | 'error';
+export type ActionStyle = 'link' | 'outline' | 'ghost';
+
+export interface NotificationItemModel {
+  id: string;
+  kind: NotificationKind;
+  type: NotificationType;
+  title?: string;
+  message: string;
+  actionLabel?: string;
+  actionStyle?: ActionStyle; // default: 'link'
+  actionAriaLabel?: string;
+  timestamp?: string; // e.g.: "Time stamp [00:00:00]"
+  dismissible?: boolean; // default: true
+  theme?: 'light' | 'dark'; // default inherited from container via class
+}
+
+@Component({
+  selector: 'app-notification-item',
+  standalone: true,
+  imports: [CommonModule, NgClass],
+  templateUrl: './notification-item.component.html',
+  styleUrls: ['./notification-item.component.scss'],
+  animations: [
+    trigger('fadeSlide', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(8px)' }),
+        animate(
+          '150ms cubic-bezier(0.2,0,0.38,0.9)',
+          style({ opacity: 1, transform: 'translateY(0)' })
+        ),
+      ]),
+      transition(':leave', [
+        animate(
+          '150ms cubic-bezier(0.2,0,0.38,0.9)',
+          style({ opacity: 0, transform: 'translateY(-8px)' })
+        ),
+      ]),
+    ]),
+  ],
+})
+export class NotificationItemComponent {
+  @Input() item!: NotificationItemModel;
+
+  @Output() action = new EventEmitter<string>();
+  @Output() dismiss = new EventEmitter<string>();
+
+  iconClass(type: NotificationType): string {
+    switch (type) {
+      case 'success':
+        return 'fa-solid fa-circle-check';
+      case 'warning':
+        return 'fa-solid fa-triangle-exclamation';
+      case 'error':
+        return 'fa-solid fa-circle-xmark';
+      default:
+        return 'fa-solid fa-circle-info';
+    }
+  }
+
+  onAction(): void {
+    this.action.emit(this.item.id);
+  }
+
+  onDismiss(): void {
+    this.dismiss.emit(this.item.id);
+  }
+
+  // Allows ESC key to dismiss when item has focus
+  @HostListener('keydown.escape')
+  handleEsc(): void {
+    if (this.item.dismissible !== false) {
+      this.onDismiss();
+    }
+  }
+}
+

--- a/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.html
@@ -1,0 +1,6 @@
+<app-notification-item
+  *ngFor="let item of items; trackBy: trackById"
+  [item]="item"
+  (action)="onAction($event)"
+  (dismiss)="onDismiss($event)"
+></app-notification-item>

--- a/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.scss
@@ -1,0 +1,21 @@
+@import "../../general/colors/colors.scss";
+
+:host.notification-host {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+:host.notification-host.toast {
+  position: fixed;
+  z-index: 1000;
+}
+
+:host.notification-host.toast.position-top-right { top: 16px; right: 16px; }
+:host.notification-host.toast.position-top-left { top: 16px; left: 16px; }
+:host.notification-host.toast.position-bottom-right { bottom: 16px; right: 16px; }
+:host.notification-host.toast.position-bottom-left { bottom: 16px; left: 16px; }
+
+:host.notification-host.theme-dark {
+  color: $neutral-100;
+}

--- a/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/notification/notification.component.ts
@@ -1,0 +1,58 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
+import { NotificationItemComponent, NotificationItemModel } from '../notification-item/notification-item.component';
+
+@Component({
+  selector: 'app-notification',
+  standalone: true,
+  imports: [CommonModule, NgClass, NotificationItemComponent],
+  templateUrl: './notification.component.html',
+  styleUrls: ['./notification.component.scss']
+})
+export class NotificationComponent {
+  @Input() items: NotificationItemModel[] = [];
+  @Input() position: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' = 'top-right';
+  @Input() theme: 'light' | 'dark' = 'light';
+
+  @Output() itemAction = new EventEmitter<string>();
+  @Output() itemDismiss = new EventEmitter<string>();
+
+  @HostBinding('attr.role') role = 'region';
+  @HostBinding('attr.aria-live') ariaLive = 'polite';
+
+  @HostBinding('class') get hostClasses(): string {
+    return [
+      'notification-host',
+      this.isToast() ? 'toast' : 'inline',
+      `position-${this.position}`,
+      `theme-${this.theme}`
+    ].join(' ');
+  }
+
+  trackById(_index: number, item: NotificationItemModel): string {
+    return item.id;
+  }
+
+  onAction(id: string): void {
+    this.itemAction.emit(id);
+  }
+
+  onDismiss(id: string): void {
+    this.items = this.items.filter(i => i.id !== id);
+    this.itemDismiss.emit(id);
+  }
+
+  isToast(): boolean {
+    return this.items.some(i => i.kind === 'toast');
+  }
+
+  // Global ESC key closes last toast
+  @HostListener('document:keydown.escape')
+  onEsc(): void {
+    const toasts = this.items.filter(i => i.kind === 'toast');
+    if (toasts.length) {
+      const last = toasts[toasts.length - 1];
+      this.onDismiss(last.id);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone notification item with inline/toast variants, actions and accessibility
- add notification container to render list and handle positioning

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c15d70e1d08331a55fce3851a6daea