### PR TITLE
feat: add standalone number input component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.html
@@ -1,0 +1,96 @@
+<label class="ni-label" [ngClass]="{ 'sr-only': hideLabel }" [attr.for]="inputId">
+  {{ label || ariaLabel || 'Label' }}
+  <ng-content select="[label-help]"></ng-content>
+</label>
+
+<div class="number-input"
+     [ngClass]="[
+       'size-' + size,
+       fluid ? 'is-fluid' : '',
+       disabled ? 'is-disabled' : '',
+       readonly ? 'is-readonly' : '',
+       invalid ? 'is-invalid' : '',
+       warn ? 'is-warn' : '',
+       skeleton ? 'is-skeleton' : '',
+       isFocused ? 'is-focused' : ''
+     ]">
+  <div class="ni-field">
+    <span class="ni-prefix">
+      <ng-content select="[prefix]"></ng-content>
+    </span>
+    <input
+      type="number"
+      class="ni-input"
+      [id]="inputId"
+      [name]="name || inputId"
+      [attr.placeholder]="placeholder"
+      [disabled]="disabled"
+      [readOnly]="readonly"
+      [attr.min]="min ?? null"
+      [attr.max]="max ?? null"
+      [attr.step]="step"
+      role="spinbutton"
+      [attr.aria-valuemin]="min ?? null"
+      [attr.aria-valuemax]="max ?? null"
+      [attr.aria-valuenow]="value ?? null"
+      [attr.aria-invalid]="invalid || null"
+      [attr.aria-describedby]="describedByIds"
+      [ngModel]="displayValue"
+      (ngModelChange)="onInputChange($event)"
+      (keydown)="onKeydown($event)"
+      (focus)="onFocus($event)"
+      (blur)="onBlur($event)"
+    />
+
+    <i *ngIf="invalid" class="fa-solid fa-circle-exclamation state-icon" aria-hidden="true"></i>
+    <i *ngIf="!invalid && warn" class="fa-solid fa-triangle-exclamation state-icon" aria-hidden="true"></i>
+
+    <div class="ni-actions">
+      <ng-content select="[action-item]"></ng-content>
+    </div>
+
+    <span class="ni-divider" aria-hidden="true" *ngIf="!hideControls"></span>
+
+    <button *ngIf="!hideControls"
+            type="button"
+            class="ni-btn minus"
+            [disabled]="disabled || readonly || isAtMin"
+            [attr.aria-disabled]="(disabled || readonly || isAtMin) ? true : null"
+            aria-label="Diminuir"
+            (pointerdown)="onPressStart('dec', $event)"
+            (pointerup)="onPressEnd()"
+            (pointerleave)="onPressEnd()"
+            (click)="decrement()">
+      &minus;
+    </button>
+
+    <span class="ni-divider" aria-hidden="true" *ngIf="!hideControls"></span>
+
+    <button *ngIf="!hideControls"
+            type="button"
+            class="ni-btn plus"
+            [disabled]="disabled || readonly || isAtMax"
+            [attr.aria-disabled]="(disabled || readonly || isAtMax) ? true : null"
+            aria-label="Aumentar"
+            (pointerdown)="onPressStart('inc', $event)"
+            (pointerup)="onPressEnd()"
+            (pointerleave)="onPressEnd()"
+            (click)="increment()">
+      &#43;
+    </button>
+  </div>
+
+  <div class="ni-messages">
+    <div *ngIf="invalid && invalidText" class="ni-error" role="alert" [id]="errorId">
+      <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+      <span>{{ invalidText }}</span>
+    </div>
+    <div *ngIf="!invalid && warn && warnText" class="ni-warn" role="status" [id]="warnId">
+      <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+      <span>{{ warnText }}</span>
+    </div>
+    <div *ngIf="!invalid && !warn && helperText" class="ni-helper" [id]="helperId">
+      {{ helperText }}
+    </div>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.scss
@@ -1,0 +1,214 @@
+@import "../../general/colors/colors.scss";
+
+.number-input {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  &.is-fluid {
+    width: 100%;
+  }
+
+  &.is-focused:not(.is-invalid):not(.is-warn) .ni-field {
+    border-color: $blue-600;
+    box-shadow: 0 0 0 2px rgba($blue-600, 0.2);
+  }
+
+  &.is-invalid .ni-field {
+    border-color: $red-800;
+    box-shadow: 0 0 0 2px rgba($red-800, 0.2);
+  }
+
+  &.is-warn .ni-field {
+    border-color: $yellow-600;
+    box-shadow: 0 0 0 2px rgba($yellow-600, 0.2);
+  }
+
+  &.is-disabled .ni-field,
+  &.is-readonly .ni-field {
+    background: $neutral-100;
+  }
+
+  &.is-disabled .ni-input,
+  &.is-disabled .ni-btn {
+    cursor: not-allowed;
+    color: $neutral-400;
+  }
+
+  &.is-readonly .ni-input,
+  &.is-readonly .ni-btn {
+    cursor: default;
+  }
+
+  &.size-sm .ni-field { height: 32px; }
+  &.size-md .ni-field { height: 40px; }
+  &.size-lg .ni-field { height: 48px; }
+
+  &.size-sm .ni-btn,
+  &.size-sm .ni-divider { height: 32px; }
+  &.size-md .ni-btn,
+  &.size-md .ni-divider { height: 40px; }
+  &.size-lg .ni-btn,
+  &.size-lg .ni-divider { height: 48px; }
+}
+
+.ni-label {
+  font-weight: 600;
+  color: $neutral-700;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ni-field {
+  display: flex;
+  align-items: center;
+  border: 1px solid $neutral-300;
+  background: $neutral-50;
+  transition: border-color 150ms cubic-bezier(0.2,0,0.38,0.9),
+              box-shadow 150ms cubic-bezier(0.2,0,0.38,0.9);
+}
+
+.ni-prefix,
+.ni-actions {
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  color: $neutral-700;
+  font-size: 0.875rem;
+}
+
+.ni-prefix:empty,
+.ni-actions:empty {
+  display: none;
+}
+
+.ni-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 0 0.5rem;
+  font-size: 1rem;
+  line-height: 1;
+  color: $neutral-800;
+  outline: none;
+  appearance: textfield;
+}
+
+.ni-input:disabled {
+  background: transparent;
+}
+
+.ni-input::-webkit-outer-spin-button,
+.ni-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.ni-input[type=number] {
+  -moz-appearance: textfield;
+}
+
+.state-icon {
+  display: flex;
+  align-items: center;
+  padding-right: 0.5rem;
+  color: $red-800;
+}
+
+.number-input.is-warn .state-icon {
+  color: $yellow-600;
+}
+
+.ni-divider {
+  align-self: stretch;
+  width: 1px;
+  background: $neutral-300;
+}
+
+.ni-btn {
+  width: 2.5rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: $neutral-700;
+  transition: background-color 150ms cubic-bezier(0.2,0,0.38,0.9),
+              transform 150ms cubic-bezier(0.2,0,0.38,0.9);
+  font-size: 1rem;
+}
+
+.ni-btn:hover:not(:disabled) {
+  background: $neutral-100;
+}
+
+.ni-btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.ni-btn:disabled {
+  color: $neutral-400;
+}
+
+.ni-messages {
+  font-size: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ni-error {
+  color: $red-800;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ni-warn {
+  color: $yellow-600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ni-helper {
+  color: $neutral-600;
+}
+
+.number-input.is-skeleton .ni-label,
+.number-input.is-skeleton .ni-field,
+.number-input.is-skeleton .ni-messages {
+  color: transparent;
+  background: $neutral-200;
+  border-color: $neutral-200;
+  pointer-events: none;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.number-input.is-skeleton .ni-btn,
+.number-input.is-skeleton .ni-divider {
+  background: $neutral-200;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: .4; }
+  100% { opacity: 1; }
+}
+
+@media (max-width: 480px) {
+  .number-input {
+    width: 100%;
+  }
+  .number-input .ni-btn {
+    width: 2.75rem;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/number-input/number-input.component.ts
@@ -1,0 +1,274 @@
+import { Component, Input, Output, EventEmitter, forwardRef } from '@angular/core';
+import { CommonModule, NgClass } from '@angular/common';
+import { FormsModule, ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+let uniqueId = 0;
+
+@Component({
+  selector: 'app-number-input',
+  standalone: true,
+  imports: [CommonModule, NgClass, FormsModule],
+  templateUrl: './number-input.component.html',
+  styleUrls: ['./number-input.component.scss'],
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => NumberInputComponent),
+    multi: true
+  }]
+})
+export class NumberInputComponent implements ControlValueAccessor {
+  private _inputId = `app-number-input-${++uniqueId}`;
+  @Input()
+  set id(value: string | undefined) {
+    if (value) {
+      this._inputId = value;
+    }
+  }
+  get inputId(): string {
+    return this._inputId;
+  }
+
+  @Input() name?: string;
+  @Input() label?: string;
+  @Input() hideLabel = false;
+  @Input() helperText?: string;
+  @Input() invalidText?: string;
+  @Input() warnText?: string;
+  @Input() placeholder?: string;
+  @Input() min: number | null = null;
+  @Input() max: number | null = null;
+  @Input() step = 1;
+  @Input() pageStep = 10;
+  @Input() precision: number | null = null;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() fluid = false;
+  @Input() disabled = false;
+  @Input() readonly = false;
+  @Input() invalid = false;
+  @Input() warn = false;
+  @Input() skeleton = false;
+  @Input() ariaLabel?: string;
+  @Input() hideControls = false;
+
+  private _value: number | null = null;
+  @Input()
+  get value(): number | null {
+    return this._value;
+  }
+  set value(v: number | null) {
+    this.writeValue(v);
+  }
+
+  @Output() valueChange = new EventEmitter<number | null>();
+  @Output('increment') incrementEvent = new EventEmitter<number>();
+  @Output('decrement') decrementEvent = new EventEmitter<number>();
+  @Output() focusin = new EventEmitter<FocusEvent>();
+  @Output() focusout = new EventEmitter<FocusEvent>();
+
+  get errorId(): string { return `${this.inputId}-error`; }
+  get warnId(): string { return `${this.inputId}-warn`; }
+  get helperId(): string { return `${this.inputId}-helper`; }
+
+  displayValue = '';
+  lastCommittedValue: number | null = null;
+  isFocused = false;
+
+  holdTimeout?: any;
+  holdInterval?: any;
+  holdDelay = 300;
+  holdIntervalMs = 100;
+  holdType: 'inc' | 'dec' | null = null;
+
+  onChange = (_: any) => {};
+  onTouched = () => {};
+
+  get isAtMin(): boolean {
+    return this.min !== null && this._value !== null && this._value <= this.min;
+  }
+
+  get isAtMax(): boolean {
+    return this.max !== null && this._value !== null && this._value >= this.max;
+  }
+
+  get describedByIds(): string | null {
+    const ids: string[] = [];
+    if (this.invalid && this.invalidText) {
+      ids.push(this.errorId);
+    } else if (this.warn && this.warnText) {
+      ids.push(this.warnId);
+    } else if (this.helperText) {
+      ids.push(this.helperId);
+    }
+    return ids.join(' ') || null;
+  }
+
+  writeValue(value: number | null): void {
+    this._value = value;
+    this.lastCommittedValue = value;
+    this.displayValue = value === null || value === undefined
+      ? ''
+      : this.precision !== null
+        ? value.toFixed(this.precision)
+        : String(value);
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  onInputChange(raw: string): void {
+    this.displayValue = raw;
+  }
+
+  commit(): void {
+    let newValue: number | null;
+    const raw = this.displayValue.trim();
+    if (raw === '') {
+      newValue = null;
+    } else {
+      const parsed = Number(raw);
+      if (isNaN(parsed)) {
+        newValue = this.lastCommittedValue;
+      } else {
+        newValue = parsed;
+      }
+    }
+
+    if (newValue !== null) {
+      if (this.precision !== null) {
+        newValue = Number(newValue.toFixed(this.precision));
+      }
+      if (this.min !== null && newValue < this.min) {
+        newValue = this.min;
+      }
+      if (this.max !== null && newValue > this.max) {
+        newValue = this.max;
+      }
+    }
+
+    if (newValue !== this._value) {
+      this._value = newValue;
+      this.onChange(newValue);
+      this.valueChange.emit(newValue);
+    }
+    this.displayValue = newValue === null || newValue === undefined
+      ? ''
+      : this.precision !== null
+        ? newValue.toFixed(this.precision)
+        : String(newValue);
+    this.lastCommittedValue = this._value;
+  }
+
+  increment(step = this.step): void {
+    if (this.disabled || this.readonly) return;
+    let newVal = (this._value ?? 0) + step;
+    if (this.max !== null && newVal > this.max) newVal = this.max;
+    this.writeValue(newVal);
+    this.onChange(newVal);
+    this.valueChange.emit(newVal);
+    this.incrementEvent.emit(newVal);
+  }
+
+  decrement(step = this.step): void {
+    if (this.disabled || this.readonly) return;
+    let newVal = (this._value ?? 0) - step;
+    if (this.min !== null && newVal < this.min) newVal = this.min;
+    this.writeValue(newVal);
+    this.onChange(newVal);
+    this.valueChange.emit(newVal);
+    this.decrementEvent.emit(newVal);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (this.disabled || this.readonly) return;
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        this.increment();
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        this.decrement();
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        this.increment(this.pageStep);
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        this.decrement(this.pageStep);
+        break;
+      case 'Home':
+        if (this.min !== null) {
+          event.preventDefault();
+          this.writeValue(this.min);
+          this.onChange(this.min);
+          this.valueChange.emit(this.min);
+        }
+        break;
+      case 'End':
+        if (this.max !== null) {
+          event.preventDefault();
+          this.writeValue(this.max);
+          this.onChange(this.max);
+          this.valueChange.emit(this.max);
+        }
+        break;
+      case 'Enter':
+        event.preventDefault();
+        this.commit();
+        break;
+      case 'Tab':
+        this.commit();
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.writeValue(this.lastCommittedValue);
+        break;
+    }
+  }
+
+  onFocus(event: FocusEvent): void {
+    this.isFocused = true;
+    this.focusin.emit(event);
+  }
+
+  onBlur(event: FocusEvent): void {
+    this.isFocused = false;
+    this.commit();
+    this.onTouched();
+    this.focusout.emit(event);
+  }
+
+  onPressStart(type: 'inc' | 'dec', ev: PointerEvent): void {
+    if (this.disabled || this.readonly || this.hideControls) return;
+    ev.preventDefault();
+    this.holdType = type;
+    this.holdTimeout = setTimeout(() => {
+      this.holdIntervalMs = 100;
+      const step = () => {
+        if (this.holdType === 'inc') {
+          if (!this.isAtMax) this.increment();
+        } else {
+          if (!this.isAtMin) this.decrement();
+        }
+        this.holdIntervalMs = Math.max(60, this.holdIntervalMs - 5);
+        this.holdInterval = setTimeout(step, this.holdIntervalMs);
+      };
+      step();
+    }, this.holdDelay);
+  }
+
+  onPressEnd(): void {
+    clearTimeout(this.holdTimeout);
+    clearTimeout(this.holdInterval);
+    this.holdType = null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Carbon-inspired NumberInputComponent with accessibility, form integration and state handling
- style number input per design tokens and responsive fluid mode

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ada343d48331b881617b9e0c00b3