### PR TITLE
feat(frontend): add pagination storybook

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.html
@@ -1,0 +1,140 @@
+<nav
+  *ngIf="variant === 'nav'; else tableBar"
+  class="pagination nav"
+  role="navigation"
+  [attr.aria-label]="ariaLabel"
+  [ngClass]="{ 'is-disabled': disabled, 'is-compact': compact }"
+>
+  <button
+    *ngIf="showFirstLast"
+    class="control first"
+    type="button"
+    [disabled]="disabled || page === 1"
+    (click)="goTo(1)"
+    aria-label="Primeira página"
+  >
+    «
+  </button>
+
+  <button
+    class="control prev"
+    type="button"
+    [disabled]="disabled || page === 1"
+    (click)="goTo(page - 1)"
+    aria-label="Página anterior"
+  >
+    ‹
+  </button>
+
+  <ul class="pages" role="list">
+    <li *ngFor="let item of navItems" role="listitem">
+      <ng-container *ngIf="isPageNumber(item); else ellipsisTpl">
+        <button
+          type="button"
+          [disabled]="disabled"
+          (click)="goTo(item)"
+          [attr.aria-current]="item === page ? 'page' : null"
+          [attr.aria-label]="item === page ? pageWord + ' ' + item : 'Ir para página ' + item"
+        >
+          {{ item }}
+        </button>
+      </ng-container>
+    </li>
+  </ul>
+
+  <button
+    class="control next"
+    type="button"
+    [disabled]="disabled || page === totalPages"
+    (click)="goTo(page + 1)"
+    aria-label="Próxima página"
+  >
+    ›
+  </button>
+
+  <button
+    *ngIf="showFirstLast"
+    class="control last"
+    type="button"
+    [disabled]="disabled || page === totalPages"
+    (click)="goTo(totalPages)"
+    aria-label="Última página"
+  >
+    »
+  </button>
+
+  <span class="sr-only" aria-live="polite">{{ pageWord }} {{ page }} {{ ofLabel }} {{ totalPages }}</span>
+
+  <ng-template #ellipsisTpl>
+    <span class="ellipsis" aria-hidden="true">…</span>
+  </ng-template>
+</nav>
+
+<ng-template #tableBar>
+  <div
+    class="pagination table-bar"
+    role="navigation"
+    [attr.aria-label]="ariaLabel"
+    [ngClass]="{ 'is-disabled': disabled, 'is-compact': compact }"
+  >
+    <div class="ppg">
+      <label [attr.for]="ids.pageSize">{{ itemsLabel }}</label>
+      <div class="select">
+        <select
+          [id]="ids.pageSize"
+          [disabled]="disabled"
+          [value]="pageSize"
+          (change)="onPageSizeChange(($event.target as HTMLSelectElement).value)"
+          aria-label="Itens por página"
+        >
+          <option *ngFor="let opt of pageSizeOptions" [value]="opt">{{ opt }}</option>
+        </select>
+        <span class="chevron" aria-hidden="true">▾</span>
+      </div>
+    </div>
+
+    <div class="range" aria-live="polite">
+      {{ rangeStart }}–{{ rangeEnd }} {{ ofLabel }} {{ totalItems }} {{ itemsWord }}
+    </div>
+
+    <div class="page-select">
+      <label [attr.for]="ids.pageSelect" class="sr-only">{{ pageWord }}</label>
+      <div class="select">
+        <select
+          [id]="ids.pageSelect"
+          [disabled]="disabled || totalPages === 0"
+          [value]="page"
+          (change)="goTo(($event.target as HTMLSelectElement).value)"
+          [attr.aria-label]="page + ' ' + ofLabel + ' ' + totalPages + ' pages'"
+        >
+          <option *ngFor="let p of pages" [value]="p">{{ p }}</option>
+        </select>
+        <span class="suffix"> {{ ofLabel }} {{ totalPages }} pages</span>
+        <span class="chevron" aria-hidden="true">▾</span>
+      </div>
+
+      <div class="controls">
+        <button
+          class="control prev"
+          type="button"
+          [disabled]="disabled || page === 1"
+          (click)="goTo(page - 1)"
+          aria-label="Página anterior"
+        >
+          ‹
+        </button>
+        <button
+          class="control next"
+          type="button"
+          [disabled]="disabled || page === totalPages"
+          (click)="goTo(page + 1)"
+          aria-label="Próxima página"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+
+    <span class="sr-only" aria-live="polite">{{ pageWord }} {{ page }} {{ ofLabel }} {{ totalPages }}</span>
+  </div>
+</ng-template>

--- a/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.scss
@@ -1,0 +1,305 @@
+@import "../../general/colors/colors.scss";
+
+.sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pagination {
+  font-family: 'IBM Plex Sans', sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: $neutral-900;
+  position: relative;
+
+  &.is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .control,
+  .pages button,
+  .select select {
+    transition: background 180ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      border-color 180ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      color 180ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  }
+
+  .control {
+    min-width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    border: 1px solid $neutral-200;
+    background: white;
+    color: $neutral-700;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 8px;
+
+    &:hover:not(:disabled) {
+      background: $neutral-50;
+      color: $neutral-800;
+    }
+
+    &:active:not(:disabled) {
+      background: $neutral-100;
+      border-color: $neutral-300;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $blue-600;
+      outline-offset: 2px;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  .pages {
+    display: inline-flex;
+    gap: 4px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    align-items: center;
+
+    button {
+      min-width: 32px;
+      height: 32px;
+      border-radius: 4px;
+      border: 1px solid transparent;
+      background: transparent;
+      color: $neutral-700;
+      font-size: 0.875rem;
+      font-weight: 500;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 8px;
+
+      &:hover:not(:disabled) {
+        background: $neutral-50;
+        color: $neutral-800;
+      }
+
+      &:active:not(:disabled) {
+        background: $neutral-100;
+        border-color: $neutral-200;
+      }
+
+      &[aria-current='page'] {
+        background: $neutral-100;
+        border-color: $neutral-200;
+        color: $neutral-900;
+        font-weight: 600;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $blue-600;
+        outline-offset: 2px;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+
+    .ellipsis {
+      padding: 0 6px;
+      color: $neutral-600;
+      font-size: 0.875rem;
+    }
+  }
+
+  .ppg,
+  .range,
+  .page-select {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    line-height: 1.3;
+  }
+
+  .ppg label {
+    color: $neutral-700;
+  }
+
+  .range {
+    color: $neutral-700;
+    white-space: nowrap;
+  }
+
+  .page-select {
+    flex-wrap: nowrap;
+
+    .controls {
+      display: inline-flex;
+      gap: 4px;
+      margin-left: 8px;
+    }
+
+    .suffix {
+      margin-left: 6px;
+      color: $neutral-700;
+      font-size: 0.75rem;
+      white-space: nowrap;
+    }
+  }
+
+  .select {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+
+    select {
+      appearance: none;
+      border: 1px solid $neutral-200;
+      border-radius: 4px;
+      height: 32px;
+      padding: 0 32px 0 12px;
+      background: white;
+      color: $neutral-800;
+      font-size: 0.875rem;
+      cursor: pointer;
+
+      &:hover:not(:disabled) {
+        border-color: $neutral-300;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $blue-600;
+        outline-offset: 2px;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        background: $neutral-100;
+        color: $neutral-500;
+      }
+    }
+
+    .chevron {
+      position: absolute;
+      right: 8px;
+      pointer-events: none;
+      color: $neutral-600;
+      font-size: 0.75rem;
+    }
+  }
+
+  &.nav {
+    justify-content: center;
+    flex-wrap: nowrap;
+  }
+
+  &.table-bar {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    row-gap: 12px;
+
+    .ppg,
+    .range,
+    .page-select {
+      flex: 1 1 auto;
+    }
+
+    .ppg {
+      min-width: 200px;
+    }
+
+    .page-select {
+      justify-content: flex-end;
+    }
+  }
+
+  &.is-compact {
+    gap: 8px;
+
+    .range {
+      display: none;
+    }
+
+    .page-select .suffix {
+      display: none;
+    }
+
+    .ppg label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .pagination {
+    gap: 8px;
+
+    .range {
+      display: none;
+    }
+
+    .page-select .suffix {
+      display: none;
+    }
+
+    .ppg label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    &.table-bar {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 8px;
+
+      .ppg,
+      .page-select {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .select {
+        width: 100%;
+      }
+
+      .page-select {
+        .select {
+          flex: 1;
+        }
+
+        .controls {
+          margin-left: 8px;
+        }
+      }
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/pagination/pagination.component.ts
@@ -1,0 +1,252 @@
+import { CommonModule, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, EventEmitter, HostListener, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+
+const NAV_MIN_BUTTONS = 3;
+
+type NavItem = number | 'ellipsis-left' | 'ellipsis-right';
+
+let uniqueIdCounter = 0;
+
+@Component({
+  selector: 'app-pagination',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgIf, NgFor],
+  templateUrl: './pagination.component.html',
+  styleUrls: ['./pagination.component.scss'],
+})
+export class PaginationComponent implements OnChanges {
+  @Input() variant: 'nav' | 'table-bar' = 'nav';
+  @Input() totalItems = 0;
+  @Input() pageSize = 10;
+  @Input() pageSizeOptions: number[] = [10, 20, 50, 100];
+  @Input() page = 1;
+  @Input() maxPageButtons = 7;
+  @Input() disabled = false;
+  @Input() showFirstLast = false;
+  @Input() ariaLabel = 'Paginação';
+  @Input() compact = false;
+  @Input() itemsLabel = 'Items per page:';
+  @Input() ofLabel = 'of';
+  @Input() itemsWord = 'items';
+  @Input() pageWord = 'Page';
+
+  @Output() pageChange = new EventEmitter<number>();
+  @Output() pageSizeChange = new EventEmitter<number>();
+
+  private readonly instanceId = ++uniqueIdCounter;
+
+  readonly ids = {
+    pageSize: `pagination-page-size-${this.instanceId}`,
+    pageSelect: `pagination-page-select-${this.instanceId}`,
+  };
+
+  navItems: NavItem[] = [];
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.totalItems = Math.max(0, Math.floor(this.totalItems));
+    this.pageSize = this.sanitizePageSize(this.pageSize);
+    this.maxPageButtons = this.sanitizeMaxButtons(this.maxPageButtons);
+
+    const clampedPage = this.clampPage(this.page);
+    const shouldEmitChange = !changes['page']?.firstChange && clampedPage !== this.page;
+    this.page = clampedPage;
+
+    this.updateNavItems();
+
+    if (shouldEmitChange) {
+      this.pageChange.emit(this.page);
+    }
+  }
+
+  get totalPages(): number {
+    const size = this.pageSize || 1;
+    const items = Math.max(0, this.totalItems);
+    return Math.max(1, Math.ceil(items / size));
+  }
+
+  get pages(): number[] {
+    const total = this.totalPages;
+    return Array.from({ length: total }, (_, index) => index + 1);
+  }
+
+  get rangeStart(): number {
+    if (this.totalItems === 0) {
+      return 0;
+    }
+    return (this.page - 1) * this.pageSize + 1;
+  }
+
+  get rangeEnd(): number {
+    if (this.totalItems === 0) {
+      return 0;
+    }
+    return Math.min(this.rangeStart + this.pageSize - 1, this.totalItems);
+  }
+
+  isPageNumber(item: NavItem): item is number {
+    return typeof item === 'number';
+  }
+
+  calcPagesForNav(): NavItem[] {
+    const total = this.totalPages;
+    const current = this.clampPage(this.page);
+    const maxButtons = Math.max(NAV_MIN_BUTTONS, this.maxPageButtons);
+
+    if (total <= maxButtons) {
+      return Array.from({ length: total }, (_, index) => index + 1);
+    }
+
+    const items: NavItem[] = [];
+    const innerCount = Math.max(1, maxButtons - 2);
+
+    if (current <= innerCount + 1) {
+      for (let i = 1; i <= innerCount + 1 && i <= total; i++) {
+        items.push(i);
+      }
+
+      if (items[items.length - 1] < total - 1) {
+        items.push('ellipsis-right');
+      }
+
+      if (items[items.length - 1] !== total) {
+        items.push(total);
+      }
+
+      return items;
+    }
+
+    if (current >= total - innerCount) {
+      items.push(1);
+
+      if (total - innerCount > 2) {
+        items.push('ellipsis-left');
+      }
+
+      const start = Math.max(2, total - innerCount);
+      for (let i = start; i <= total; i++) {
+        items.push(i);
+      }
+
+      return items;
+    }
+
+    const start = Math.max(2, current - Math.floor(innerCount / 2));
+    const end = Math.min(total - 1, start + innerCount - 1);
+    const adjustedStart = Math.max(2, end - innerCount + 1);
+    items.push(1);
+    if (adjustedStart > 2) {
+      items.push('ellipsis-left');
+    }
+
+    for (let i = adjustedStart; i <= end; i++) {
+      if (i > 1 && i < total) {
+        items.push(i);
+      }
+    }
+
+    if (end < total - 1) {
+      items.push('ellipsis-right');
+    }
+
+    items.push(total);
+
+    return items;
+  }
+
+  goTo(page: number | string): void {
+    if (this.disabled) {
+      return;
+    }
+
+    const targetPage = typeof page === 'string' ? parseInt(page, 10) : page;
+    if (!Number.isFinite(targetPage)) {
+      return;
+    }
+
+    const clamped = this.clampPage(targetPage);
+    if (clamped === this.page) {
+      return;
+    }
+
+    this.page = clamped;
+    this.updateNavItems();
+    this.pageChange.emit(this.page);
+  }
+
+  onPageSizeChange(size: number | string): void {
+    if (this.disabled) {
+      return;
+    }
+
+    const value = typeof size === 'string' ? parseInt(size, 10) : size;
+    if (!Number.isFinite(value)) {
+      return;
+    }
+
+    const sanitized = this.sanitizePageSize(value);
+    if (sanitized === this.pageSize) {
+      return;
+    }
+
+    this.pageSize = sanitized;
+    this.page = 1;
+    this.updateNavItems();
+    this.pageSizeChange.emit(this.pageSize);
+    this.pageChange.emit(this.page);
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    if (this.disabled || this.variant !== 'nav') {
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        event.preventDefault();
+        this.goTo(this.page - 1);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        this.goTo(this.page + 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.goTo(1);
+        break;
+      case 'End':
+        event.preventDefault();
+        this.goTo(this.totalPages);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private updateNavItems(): void {
+    if (this.variant === 'nav') {
+      this.navItems = this.calcPagesForNav();
+    } else {
+      this.navItems = [];
+    }
+  }
+
+  private clampPage(page: number): number {
+    if (!Number.isFinite(page)) {
+      return 1;
+    }
+
+    const total = this.totalPages;
+    return Math.min(Math.max(1, Math.floor(page)), total);
+  }
+
+  private sanitizePageSize(size: number): number {
+    const sanitized = Math.max(1, Math.floor(Number.isFinite(size) ? size : 1));
+    return sanitized;
+  }
+
+  private sanitizeMaxButtons(count: number): number {
+    const sanitized = Math.max(NAV_MIN_BUTTONS, Math.floor(Number.isFinite(count) ? count : NAV_MIN_BUTTONS));
+    return sanitized;
+  }
+}

--- a/frontend/agentes-frontend/src/stories/componentes/pagination/pagination.stories.ts
+++ b/frontend/agentes-frontend/src/stories/componentes/pagination/pagination.stories.ts
@@ -1,0 +1,115 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { PaginationComponent } from '../../../app/shared/components/pagination/pagination.component';
+
+const meta: Meta<PaginationComponent> = {
+  title: 'Shared/Components/Pagination',
+  component: PaginationComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, PaginationComponent],
+    }),
+  ],
+  args: {
+    variant: 'nav',
+    totalItems: 300,
+    pageSize: 10,
+    pageSizeOptions: [10, 20, 50, 100],
+    page: 1,
+    maxPageButtons: 7,
+    disabled: false,
+    showFirstLast: false,
+    ariaLabel: 'Paginação',
+    compact: false,
+    itemsLabel: 'Items per page:',
+    ofLabel: 'of',
+    itemsWord: 'items',
+    pageWord: 'Page',
+  },
+  argTypes: {
+    variant: { control: 'select', options: ['nav', 'table-bar'] },
+    totalItems: { control: { type: 'number', min: 0 } },
+    pageSize: { control: { type: 'number', min: 1 } },
+    pageSizeOptions: { control: 'object' },
+    page: { control: { type: 'number', min: 1 } },
+    maxPageButtons: { control: { type: 'number', min: 3 } },
+    disabled: { control: 'boolean' },
+    showFirstLast: { control: 'boolean' },
+    ariaLabel: { control: 'text' },
+    compact: { control: 'boolean' },
+    itemsLabel: { control: 'text' },
+    ofLabel: { control: 'text' },
+    itemsWord: { control: 'text' },
+    pageWord: { control: 'text' },
+    pageChange: { action: 'pageChange' },
+    pageSizeChange: { action: 'pageSizeChange' },
+  },
+  parameters: {
+    controls: { expanded: true },
+    docs: {
+      description: {
+        component:
+          'Componente de paginação Carbon-like com variantes para navegação ou barra de tabela, responsivo e acessível.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<PaginationComponent>;
+
+/** Ajuste livre via Controls */
+export const Playground: Story = {
+  name: 'Playground',
+};
+
+/** Navegação padrão com reticências e botões numéricos */
+export const NavManyPages: Story = {
+  args: {
+    variant: 'nav',
+    totalItems: 120,
+    pageSize: 10,
+    page: 6,
+    maxPageButtons: 7,
+  },
+};
+
+/** Variante nav com botões de primeira/última página */
+export const NavWithBoundaries: Story = {
+  args: {
+    variant: 'nav',
+    totalItems: 200,
+    pageSize: 10,
+    page: 4,
+    showFirstLast: true,
+  },
+};
+
+/** Barra de tabela completa com seleção de itens por página */
+export const TableBar: Story = {
+  args: {
+    variant: 'table-bar',
+    totalItems: 430,
+    pageSize: 50,
+    page: 3,
+  },
+};
+
+/** Exemplo compacto (forçado) para telas menores */
+export const Compact: Story = {
+  args: {
+    variant: 'table-bar',
+    totalItems: 150,
+    pageSize: 20,
+    page: 2,
+    compact: true,
+  },
+};
+
+/** Estado desabilitado */
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};


### PR DESCRIPTION
## Summary
- add Storybook metadata for the Pagination component including default args and controls
- provide stories covering nav usage with ellipses, boundary buttons, table bar layout, compact mode, and disabled state

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cbea4b419c8331b77e247edbbe752a