### PR TITLE
feat(frontend): add password input component

### DIFF
--- a/frontend/agentes-frontend/.gitignore
+++ b/frontend/agentes-frontend/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
+storybook-static/
 
 # System files
 .DS_Store

--- a/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.html
@@ -1,0 +1,100 @@
+<div class="pi" [ngClass]="containerClasses">
+  <label
+    *ngIf="label"
+    class="pi-label"
+    [ngClass]="{ 'sr-only': hideLabel }"
+    [attr.for]="inputId"
+  >
+    {{ label }}
+  </label>
+
+  <div class="pi-field">
+    <input
+      class="pi-control"
+      [id]="inputId"
+      [attr.name]="name || null"
+      [attr.autocomplete]="autocomplete"
+      [attr.maxLength]="maxLength ?? null"
+      [disabled]="disabled || skeleton"
+      [readOnly]="readonly"
+      [required]="required"
+      [attr.aria-required]="required ? true : null"
+      [attr.aria-invalid]="showError ? true : null"
+      [attr.aria-describedby]="describedBy"
+      [attr.aria-label]="computedAriaLabel"
+      [type]="fieldType"
+      [(ngModel)]="value"
+      [attr.placeholder]="placeholder"
+      (input)="onInput($event)"
+      (focus)="onFocus()"
+      (blur)="onBlur()"
+      (keydown)="onKeydown($event)"
+    />
+
+    <div
+      class="pi-actions"
+      *ngIf="!skeleton && (showError || showWarning || (toggleVisibility && !readonly && !disabled))"
+    >
+      <i
+        *ngIf="showError"
+        class="fa fa-circle-exclamation"
+        aria-hidden="true"
+      ></i>
+      <i
+        *ngIf="!showError && showWarning"
+        class="fa fa-triangle-exclamation"
+        aria-hidden="true"
+      ></i>
+      <button
+        *ngIf="toggleVisibility && !readonly && !disabled"
+        type="button"
+        class="pi-eye"
+        (click)="onToggleVisibility()"
+        [attr.aria-pressed]="visible"
+        [attr.aria-label]="visible ? 'Ocultar senha' : 'Mostrar senha'"
+        [title]="visible ? 'Ocultar senha' : 'Mostrar senha'"
+      >
+        <i [class]="'fa ' + (visible ? 'fa-eye-slash' : 'fa-eye')" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="pi-meta"
+    *ngIf="!skeleton && (helperText || (showError && errorMessage) || (!showError && showWarning && warningMessage) || (maxLength !== null))"
+  >
+    <ng-container>
+      <p
+        class="helper"
+        *ngIf="helperText && !showError && !showWarning"
+        [id]="helperId"
+        aria-live="polite"
+      >
+        {{ helperText }}
+      </p>
+      <p
+        class="error"
+        *ngIf="showError && errorMessage"
+        [id]="errorId"
+        role="alert"
+      >
+        {{ errorMessage }}
+      </p>
+      <p
+        class="warning"
+        *ngIf="!showError && showWarning && warningMessage"
+        [id]="warnId"
+        aria-live="polite"
+      >
+        {{ warningMessage }}
+      </p>
+    </ng-container>
+    <span
+      class="counter"
+      *ngIf="maxLength !== null"
+      [id]="counterId"
+    >
+      {{ value?.length || 0 }} / {{ maxLength }}
+    </span>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.scss
@@ -1,0 +1,333 @@
+@import "../../general/colors/colors.scss";
+
+:host {
+  display: inline-block;
+  max-width: 100%;
+  font-family: inherit;
+}
+
+.pi {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 24rem;
+  color: $neutral-800;
+  transition: color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+
+  &.is-fluid {
+    max-width: 100%;
+  }
+
+  &.is-disabled {
+    cursor: not-allowed;
+  }
+
+  &.is-readonly {
+    cursor: default;
+  }
+
+  &.is-focused:not(.is-invalid):not(.is-warn) .pi-field {
+    border-color: $blue-600;
+    box-shadow: 0 0 0 2px rgba($blue-600, 0.2);
+  }
+
+  &.is-invalid .pi-field {
+    border-color: $red-700;
+    box-shadow: 0 0 0 2px rgba($red-700, 0.18);
+  }
+
+  &.is-invalid.is-focused .pi-field {
+    border-color: $red-700;
+    box-shadow: 0 0 0 2px rgba($red-700, 0.2);
+  }
+
+  &.is-warn:not(.is-invalid) .pi-field {
+    border-color: $yellow-700;
+    box-shadow: 0 0 0 2px rgba($yellow-700, 0.2);
+  }
+
+  &.is-warn.is-focused:not(.is-invalid) .pi-field {
+    border-color: $yellow-700;
+    box-shadow: 0 0 0 2px rgba($yellow-700, 0.24);
+  }
+
+  &.is-disabled .pi-field,
+  &.is-skeleton .pi-field {
+    background: $neutral-100;
+    border-color: $neutral-200;
+    cursor: not-allowed;
+  }
+
+  &.is-readonly .pi-field {
+    background: $neutral-50;
+    cursor: default;
+  }
+
+  &.is-disabled .pi-label {
+    color: $neutral-500;
+  }
+}
+
+.pi-label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: $neutral-700;
+  margin: 0;
+}
+
+.pi-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  border: 1px solid $neutral-300;
+  background: $neutral-50;
+  border-radius: 4px;
+  box-sizing: border-box;
+  padding: 0 1rem;
+  transition: border-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+              box-shadow 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+              background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.pi.size-sm .pi-field {
+  min-height: 32px;
+  padding: 0 0.75rem;
+}
+
+.pi.size-md .pi-field {
+  min-height: 40px;
+  padding: 0 1rem;
+}
+
+.pi.size-lg .pi-field {
+  min-height: 48px;
+  padding: 0 1.25rem;
+}
+
+.pi-control {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: $neutral-800;
+  line-height: 1.4;
+  padding: 0;
+  font-size: 1rem;
+}
+
+.pi.size-sm .pi-control {
+  font-size: 0.875rem;
+}
+
+.pi-control::placeholder {
+  color: $neutral-500;
+}
+
+.pi-control:focus {
+  outline: none;
+}
+
+.pi:not(.is-disabled):not(.is-readonly):not(.is-skeleton) .pi-field:hover {
+  border-color: $neutral-400;
+}
+
+.pi-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 0.25rem;
+}
+
+.pi-actions i {
+  font-size: 1rem;
+  color: $neutral-500;
+}
+
+.pi-eye {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  color: $neutral-600;
+  cursor: pointer;
+  transition: color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+              background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.pi-eye:hover {
+  color: $neutral-700;
+  background-color: rgba($neutral-400, 0.16);
+}
+
+.pi-eye:focus-visible {
+  outline: 2px solid $blue-600;
+  outline-offset: 2px;
+}
+
+.pi.is-invalid .pi-actions i {
+  color: $red-700;
+}
+
+.pi.is-warn:not(.is-invalid) .pi-actions i {
+  color: $yellow-700;
+}
+
+.pi.is-disabled .pi-control,
+.pi.is-disabled .pi-actions i,
+.pi.is-disabled .pi-eye {
+  color: $neutral-400;
+  cursor: not-allowed;
+}
+
+.pi.is-disabled .pi-meta {
+  color: $neutral-400;
+}
+
+.pi.is-disabled .counter {
+  color: $neutral-400;
+}
+
+.pi.is-disabled .pi-control::placeholder {
+  color: $neutral-300;
+}
+
+.pi.is-disabled .pi-eye:hover {
+  background: transparent;
+}
+
+.pi.is-readonly .pi-control {
+  color: $neutral-700;
+  cursor: default;
+}
+
+.pi.is-invalid .pi-meta {
+  color: $red-700;
+}
+
+.pi.is-warn:not(.is-invalid) .pi-meta {
+  color: $yellow-700;
+}
+
+.pi-meta {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: $neutral-600;
+}
+
+.pi-meta p {
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.counter {
+  margin-left: auto;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .pi {
+    gap: 0.375rem;
+  }
+
+  .pi-field {
+    gap: 0.375rem;
+  }
+
+  .pi-actions {
+    gap: 0.25rem;
+  }
+
+  .pi-eye {
+    min-width: 28px;
+    min-height: 28px;
+  }
+
+  .pi-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .counter {
+    align-self: flex-end;
+  }
+}
+
+.pi.is-skeleton {
+  pointer-events: none;
+}
+
+.pi.is-skeleton .pi-label,
+.pi.is-skeleton .pi-field,
+.pi.is-skeleton .pi-meta,
+.pi.is-skeleton .counter {
+  position: relative;
+  color: transparent;
+}
+
+.pi.is-skeleton .pi-control {
+  opacity: 0;
+}
+
+.pi.is-skeleton .pi-actions {
+  display: none;
+}
+
+.pi.is-skeleton .pi-field {
+  border-color: $neutral-200;
+}
+
+.pi.is-skeleton .pi-label::after,
+.pi.is-skeleton .pi-field::after,
+.pi.is-skeleton .pi-meta::after,
+.pi.is-skeleton .counter::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 4px;
+  background: linear-gradient(90deg, $neutral-200 0%, $neutral-300 50%, $neutral-200 100%);
+  background-size: 200% 100%;
+  animation: pi-skeleton 1.2s ease-in-out infinite;
+}
+
+.pi.is-skeleton .pi-label::after {
+  border-radius: 2px;
+}
+
+.pi.is-skeleton .pi-meta::after,
+.pi.is-skeleton .counter::after {
+  border-radius: 2px;
+}
+
+@keyframes pi-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/password-input/password-input.component.ts
@@ -1,0 +1,198 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, EventEmitter, Input, Output, booleanAttribute, numberAttribute } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+let uniqueId = 0;
+
+@Component({
+  selector: 'app-password-input',
+  standalone: true,
+  imports: [CommonModule, NgClass, FormsModule],
+  templateUrl: './password-input.component.html',
+  styleUrls: ['./password-input.component.scss']
+})
+export class PasswordInputComponent {
+  private _inputId = `app-password-input-${++uniqueId}`;
+  private _value = '';
+
+  @Input()
+  set id(value: string | undefined) {
+    if (value) {
+      this._inputId = value;
+    }
+  }
+  get id(): string {
+    return this._inputId;
+  }
+  get inputId(): string {
+    return this._inputId;
+  }
+
+  @Input() label?: string;
+  @Input() ariaLabel?: string;
+  @Input() placeholder = 'Password';
+  @Input() name?: string;
+  @Input() autocomplete: 'current-password' | 'new-password' | 'off' = 'current-password';
+  @Input() helperText?: string;
+  @Input() errorMessage?: string;
+  @Input() warningMessage?: string;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input({ transform: booleanAttribute }) fluid = false;
+  @Input({ transform: booleanAttribute }) disabled = false;
+  @Input({ transform: booleanAttribute }) readonly = false;
+  @Input({ transform: booleanAttribute }) required = false;
+  @Input({ transform: booleanAttribute }) hideLabel = false;
+  @Input({ transform: booleanAttribute }) skeleton = false;
+  @Input({ transform: booleanAttribute }) toggleVisibility = true;
+  @Input({ transform: booleanAttribute }) warn = false;
+  @Input({ transform: booleanAttribute }) invalid = false;
+  @Input({ transform: booleanAttribute }) clearable = false;
+  private _maxLength: number | null = null;
+
+  @Input({ transform: numberAttribute })
+  set maxLength(value: number | null) {
+    if (value === null || value === undefined || Number.isNaN(value)) {
+      this._maxLength = null;
+    } else {
+      this._maxLength = value;
+    }
+  }
+  get maxLength(): number | null {
+    return this._maxLength;
+  }
+
+  @Input()
+  get value(): string {
+    return this._value;
+  }
+  set value(val: string | undefined | null) {
+    this._value = val ?? '';
+  }
+
+  @Output() valueChange = new EventEmitter<string>();
+  @Output() changed = new EventEmitter<string>();
+  @Output() toggledVisibility = new EventEmitter<boolean>();
+  @Output() focused = new EventEmitter<void>();
+  @Output() blurred = new EventEmitter<void>();
+
+  visible = false;
+  isFocused = false;
+
+  get helperId(): string {
+    return `${this.inputId}-helper`;
+  }
+
+  get errorId(): string {
+    return `${this.inputId}-error`;
+  }
+
+  get warnId(): string {
+    return `${this.inputId}-warn`;
+  }
+
+  get counterId(): string {
+    return `${this.inputId}-counter`;
+  }
+
+  get describedBy(): string | null {
+    if (this.skeleton) {
+      return null;
+    }
+    const ids: string[] = [];
+    if (this.showError && this.errorMessage) {
+      ids.push(this.errorId);
+    } else if (this.showWarning && this.warningMessage) {
+      ids.push(this.warnId);
+    } else if (this.helperText) {
+      ids.push(this.helperId);
+    }
+    if (this.maxLength !== null) {
+      ids.push(this.counterId);
+    }
+    return ids.length ? ids.join(' ') : null;
+  }
+
+  get showError(): boolean {
+    if (this.skeleton) {
+      return false;
+    }
+    return this.invalid || !!this.errorMessage;
+  }
+
+  get showWarning(): boolean {
+    if (this.skeleton) {
+      return false;
+    }
+    if (this.showError) {
+      return false;
+    }
+    return this.warn || !!this.warningMessage;
+  }
+
+  get fieldType(): string {
+    return this.visible ? 'text' : 'password';
+  }
+
+  get computedAriaLabel(): string | null {
+    if (this.hideLabel || !this.label) {
+      return this.ariaLabel || this.label || this.placeholder || 'Password';
+    }
+    return null;
+  }
+
+  get containerClasses(): Record<string, boolean> {
+    return {
+      [`size-${this.size}`]: true,
+      'is-fluid': this.fluid,
+      'is-disabled': this.disabled || this.skeleton,
+      'is-readonly': this.readonly,
+      'is-invalid': this.showError,
+      'is-warn': !this.showError && this.showWarning,
+      'is-focused': this.isFocused,
+      'is-skeleton': this.skeleton
+    };
+  }
+
+  onToggleVisibility(): void {
+    if (this.disabled || this.readonly || this.skeleton) {
+      return;
+    }
+    this.visible = !this.visible;
+    this.toggledVisibility.emit(this.visible);
+  }
+
+  onInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const newValue = target?.value ?? '';
+    this.value = newValue;
+    this.valueChange.emit(this._value);
+    this.changed.emit(this._value);
+  }
+
+  onFocus(): void {
+    if (this.skeleton) {
+      return;
+    }
+    this.isFocused = true;
+    this.focused.emit();
+  }
+
+  onBlur(): void {
+    this.isFocused = false;
+    this.blurred.emit();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && this.clearable && !this.disabled && !this.readonly && !this.skeleton) {
+      event.stopPropagation();
+      event.preventDefault();
+      const target = event.target as HTMLInputElement | null;
+      this.value = '';
+      if (target) {
+        target.value = '';
+      }
+      this.valueChange.emit(this._value);
+      this.changed.emit(this._value);
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/stories/componentes/password-input/password-input.stories.ts
+++ b/frontend/agentes-frontend/src/stories/componentes/password-input/password-input.stories.ts
@@ -1,0 +1,274 @@
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PasswordInputComponent } from '../../../app/shared/components/password-input/password-input.component';
+
+type Story = StoryObj<PasswordInputComponent>;
+
+const meta: Meta<PasswordInputComponent> = {
+  title: 'Shared/Components/PasswordInput',
+  component: PasswordInputComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [CommonModule, FormsModule, PasswordInputComponent],
+    }),
+  ],
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    controls: { expanded: true },
+    docs: {
+      description: {
+        component:
+          'Campo de senha seguindo o Carbon Design System. Suporta estados (focus/invalid/warn/disabled/readonly/skeleton), modo fluid, contador de caracteres, rótulo oculto e alternância de visibilidade.',
+      },
+    },
+  },
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    fluid: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readonly: { control: 'boolean' },
+    required: { control: 'boolean' },
+    hideLabel: { control: 'boolean' },
+    skeleton: { control: 'boolean' },
+    toggleVisibility: { control: 'boolean' },
+    warn: { control: 'boolean' },
+    invalid: { control: 'boolean' },
+    helperText: { control: 'text' },
+    errorMessage: { control: 'text' },
+    warningMessage: { control: 'text' },
+    label: { control: 'text' },
+    ariaLabel: { control: 'text' },
+    placeholder: { control: 'text' },
+    maxLength: { control: { type: 'number', min: 0 } },
+    valueChange: { action: 'valueChange' },
+    changed: { action: 'changed' },
+    toggledVisibility: { action: 'toggledVisibility' },
+    focused: { action: 'focused' },
+    blurred: { action: 'blurred' },
+  },
+  args: {
+    label: 'Senha',
+    helperText: 'Mínimo 8 caracteres, incluindo letra e número.',
+    placeholder: 'Password',
+    size: 'md',
+    fluid: false,
+    disabled: false,
+    readonly: false,
+    required: false,
+    hideLabel: false,
+    skeleton: false,
+    toggleVisibility: true,
+    warn: false,
+    invalid: false,
+    errorMessage: '',
+    warningMessage: '',
+    maxLength: null,
+  },
+};
+
+export default meta;
+
+const withModel = (initial = 'Senha@123') => ({
+  props: { model: initial },
+});
+
+export const Playground: Story = {
+  render: (args) => ({
+    ...withModel('Senha@123'),
+    props: { ...args },
+    template: `
+      <div style="min-width:320px;max-width:420px;">
+        <app-password-input
+          [label]="label"
+          [ariaLabel]="ariaLabel"
+          [placeholder]="placeholder"
+          [helperText]="helperText"
+          [errorMessage]="errorMessage"
+          [warningMessage]="warningMessage"
+          [size]="size"
+          [fluid]="fluid"
+          [disabled]="disabled"
+          [readonly]="readonly"
+          [required]="required"
+          [hideLabel]="hideLabel"
+          [skeleton]="skeleton"
+          [toggleVisibility]="toggleVisibility"
+          [maxLength]="maxLength"
+          [warn]="warn"
+          [invalid]="invalid"
+          [(ngModel)]="model"
+          (valueChange)="valueChange($event)"
+          (changed)="changed($event)"
+          (toggledVisibility)="toggledVisibility($event)"
+          (focused)="focused()"
+          (blurred)="blurred()"
+        ></app-password-input>
+        <p style="margin-top:8px;font-size:12px;color:#6f6f6f;">Valor atual: {{ model }}</p>
+      </div>
+    `,
+  }),
+};
+
+export const Sizes: Story = {
+  render: () => ({
+    props: {
+      sm: '',
+      md: 'Senha@123',
+      lg: 'SenhaComplexa!2024',
+    },
+    template: `
+      <div style="display:grid;gap:16px;min-width:320px;max-width:420px;">
+        <app-password-input label="Senha pequena" size="sm" [(ngModel)]="sm"></app-password-input>
+        <app-password-input label="Senha média" size="md" [(ngModel)]="md"></app-password-input>
+        <app-password-input label="Senha grande" size="lg" [(ngModel)]="lg"></app-password-input>
+      </div>
+    `,
+  }),
+};
+
+export const Fluid: Story = {
+  args: { fluid: true },
+  render: (args) => ({
+    ...withModel('SenhaFluid99'),
+    props: { ...args },
+    template: `
+      <div style="width:520px;max-width:100%;">
+        <app-password-input
+          [label]="label"
+          [fluid]="true"
+          [helperText]="helperText"
+          [(ngModel)]="model"
+        ></app-password-input>
+      </div>
+    `,
+  }),
+};
+
+export const Invalid: Story = {
+  args: {
+    invalid: true,
+    errorMessage: 'Senha inválida. Use ao menos 8 caracteres, letra e número.',
+  },
+  render: (args) => ({
+    ...withModel('123'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [invalid]="true"
+        [errorMessage]="errorMessage"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const Warning: Story = {
+  args: {
+    warn: true,
+    warningMessage: 'Considere adicionar caracteres especiais.',
+  },
+  render: (args) => ({
+    ...withModel('Senha123'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [warn]="true"
+        [warningMessage]="warningMessage"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    helperText: 'Campo desabilitado',
+  },
+  render: (args) => ({
+    ...withModel('SenhaBloqueada!'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [disabled]="true"
+        [helperText]="helperText"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const Readonly: Story = {
+  args: {
+    readonly: true,
+    helperText: 'Somente leitura',
+  },
+  render: (args) => ({
+    ...withModel('SenhaSomenteLeitura!'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [readonly]="true"
+        [helperText]="helperText"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const Skeleton: Story = {
+  args: { skeleton: true, label: ' ', helperText: ' ' },
+  render: (args) => ({
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [helperText]="helperText"
+        [skeleton]="true"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const WithMaxLength: Story = {
+  args: { maxLength: 16 },
+  render: (args) => ({
+    ...withModel('Senha@123'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [helperText]="helperText"
+        [maxLength]="maxLength"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};
+
+export const HideLabelWithAria: Story = {
+  args: {
+    hideLabel: true,
+    ariaLabel: 'Senha da conta',
+    helperText: 'Etiqueta visual oculta, mas acessível via aria-label.',
+  },
+  render: (args) => ({
+    ...withModel('SenhaSecreta!'),
+    props: { ...args },
+    template: `
+      <app-password-input
+        [label]="label"
+        [ariaLabel]="ariaLabel"
+        [hideLabel]="true"
+        [helperText]="helperText"
+        [(ngModel)]="model"
+      ></app-password-input>
+    `,
+  }),
+};


### PR DESCRIPTION
## Summary
- add a standalone PasswordInput component aligned with the design system and accessibility requirements
- implement template logic for helper, error/warning states, visibility toggle, and character counter
- style the component with Carbon-inspired tokens, responsive sizing, and skeleton/interaction states
- document the PasswordInput in Storybook with comprehensive state variants and ignore generated static output

## Testing
- npm run build-storybook
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d304cdf36c8331b3d56333947af05b