### PR TITLE
feat: add progress bar components

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/index.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/index.ts
@@ -1,0 +1,2 @@
+export * from './progress-bar.component';
+export * from './progress-bar-item.component';

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: none;
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar-item.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+export type ProgressBarItemStatus = 'default' | 'success' | 'error' | 'neutral';
+
+@Component({
+  selector: 'app-progress-bar-item',
+  standalone: true,
+  templateUrl: './progress-bar-item.component.html',
+  styleUrls: ['./progress-bar-item.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressBarItemComponent {
+  @Input() label?: string;
+  @Input() value: number = 0;
+  @Input() status: ProgressBarItemStatus = 'default';
+  @Input() tooltip?: string;
+  @Input() icon?: string;
+  @Input() ariaLabel?: string;
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.html
@@ -1,0 +1,104 @@
+<div
+  [attr.id]="id"
+  class="pb"
+  [ngClass]="{
+    'pb-inline': inline,
+    'pb-skeleton': skeleton,
+    'pb-indeterminate': indeterminate,
+    'pb-animated': animated,
+    'pb-no-animate': !animated,
+    'pb-striped': striped && isDeterminate && !segmented,
+    'pb-segmented': segmented,
+    'pb-size-sm': size === 'sm',
+    'pb-size-lg': size === 'lg',
+    'pb-status-success': status === 'success',
+    'pb-status-error': status === 'error',
+    'pb-status-neutral': status === 'neutral',
+    'pb-has-helper': !!helperText,
+    'pb-show-percentage': showPercentage && isDeterminate,
+    'pb-stacked-labels': stackedLabels && segmented && showItemLabels
+  }"
+  role="progressbar"
+  tabindex="0"
+  [attr.aria-busy]="ariaBusy"
+  [attr.aria-valuemin]="ariaValueMin"
+  [attr.aria-valuemax]="ariaValueMax"
+  [attr.aria-valuenow]="ariaValueNow"
+  [attr.aria-label]="ariaLabelAttr"
+  [attr.aria-labelledby]="ariaLabelledby"
+  [attr.aria-describedby]="ariaDescribedByAttr"
+>
+  <span
+    class="sr-only pb-live"
+    [attr.id]="liveRegionId"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {{ liveMessage }}
+  </span>
+
+  <div class="pb-main">
+    <div class="pb-header" *ngIf="label || statusIcon || (showPercentage && isDeterminate)">
+      <div class="pb-header-main">
+        <label *ngIf="label" class="pb-label" [attr.id]="labelId">
+          {{ label }}
+        </label>
+        <span class="pb-status-icon" *ngIf="statusIcon" aria-hidden="true">{{ statusIcon }}</span>
+      </div>
+      <span class="pb-percentage" *ngIf="showPercentage && isDeterminate">
+        {{ percentageText }}
+      </span>
+    </div>
+
+    <div class="pb-track" role="presentation">
+      <ng-container *ngIf="segmented; else determinateBar">
+        <div class="pb-segments" role="presentation">
+          <div
+            class="pb-segment"
+            *ngFor="let segment of segments"
+            role="presentation"
+            [ngClass]="['pb-segment-status-' + segment.status]"
+            [style.flex-basis.%]="segment.percent"
+            [attr.title]="segment.tooltip || null"
+            [attr.data-label]="segment.label || segment.ariaLabel || null"
+          ></div>
+        </div>
+      </ng-container>
+      <ng-template #determinateBar>
+        <div
+          class="pb-fill"
+          [ngClass]="{
+            'pb-fill-indeterminate': indeterminate,
+            'pb-fill-striped': striped && isDeterminate,
+            'pb-fill-skeleton': skeleton
+          }"
+          [style.--pb]="percentStyle"
+        ></div>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="pb-item-labels" *ngIf="segmented && showItemLabels && segments.length">
+    <div class="pb-item-label" *ngFor="let segment of segments">
+      <div class="pb-item-label-text">
+        <span class="pb-item-icon" *ngIf="segment.icon" [class]="segment.icon" aria-hidden="true"></span>
+        <span>{{ segment.label || segment.ariaLabel || 'Segmento' }}</span>
+      </div>
+      <span class="pb-item-label-value">{{ segment.percent | number: '1.0-0' }}%</span>
+    </div>
+  </div>
+
+  <p class="pb-helper" *ngIf="helperText" [attr.id]="helperId">
+    {{ helperText }}
+  </p>
+
+  <ul class="pb-segment-list sr-only" role="list" *ngIf="segmented && segments.length">
+    <li role="listitem" *ngFor="let segment of segments">
+      {{ segment.ariaLabel || segment.label || 'Segmento' }}: {{ segment.percent | number: '1.0-0' }}%
+    </li>
+  </ul>
+
+  <div class="pb-item-host" aria-hidden="true">
+    <ng-content select="app-progress-bar-item"></ng-content>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.scss
@@ -1,0 +1,386 @@
+@import "../../general/colors/colors.scss";
+
+:host {
+  display: block;
+  width: 100%;
+  --pb-h-sm: 4px;
+  --pb-h-md: 8px;
+  --pb-h-lg: 12px;
+  --pb-radius: 999px;
+  --pb-ease: cubic-bezier(0.2, 0, 0.38, 0.9);
+  --pb-dur: 150ms;
+  --pb-height: var(--pb-h-md);
+  --pb-color: $blue-600;
+  --pb-helper-color: $neutral-400;
+  --pb-label-size: 0.875rem;
+  --pb-helper-size: 0.75rem;
+}
+
+:host(.pb-size-sm) {
+  --pb-height: var(--pb-h-sm);
+  --pb-label-size: 0.75rem;
+  --pb-helper-size: 0.6875rem;
+}
+
+:host(.pb-size-lg) {
+  --pb-height: var(--pb-h-lg);
+  --pb-label-size: 1rem;
+  --pb-helper-size: 0.875rem;
+}
+
+:host(.pb-status-success) {
+  --pb-color: $green-600;
+  --pb-helper-color: $green-600;
+}
+
+:host(.pb-status-error) {
+  --pb-color: $red-600;
+  --pb-helper-color: $red-600;
+}
+
+:host(.pb-status-neutral) {
+  --pb-color: $neutral-400;
+  --pb-helper-color: $neutral-400;
+}
+
+.pb {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  outline: none;
+}
+
+.pb:focus-visible {
+  outline: 2px solid $blue-600;
+  outline-offset: 2px;
+}
+
+.pb-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pb-header-main {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pb-label {
+  font-size: var(--pb-label-size);
+  font-weight: 600;
+  color: $neutral-600;
+}
+
+.pb-status-icon {
+  font-size: var(--pb-label-size);
+  color: var(--pb-color);
+}
+
+.pb-percentage {
+  font-size: var(--pb-label-size);
+  font-weight: 600;
+  color: $neutral-600;
+  white-space: nowrap;
+}
+
+.pb-track {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: var(--pb-height);
+  background-color: $neutral-200;
+  border-radius: var(--pb-radius);
+  overflow: hidden;
+}
+
+.pb-fill {
+  position: relative;
+  height: 100%;
+  width: var(--pb, 0);
+  max-width: 100%;
+  background-color: var(--pb-color);
+  transition: width var(--pb-dur) var(--pb-ease), background-color var(--pb-dur) var(--pb-ease);
+}
+
+.pb-fill.pb-fill-skeleton {
+  width: 100%;
+  background: linear-gradient(
+    90deg,
+    $neutral-200 0%,
+    $neutral-300 50%,
+    $neutral-200 100%
+  );
+  animation: pb-shimmer 1.5s infinite;
+}
+
+.pb-fill.pb-fill-indeterminate {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 35%;
+  transform: translateX(-100%);
+  animation: pb-indeterminate 1.2s infinite;
+}
+
+.pb.pb-no-animate .pb-fill,
+.pb.pb-no-animate .pb-segment,
+.pb.pb-no-animate .pb-fill-indeterminate,
+.pb.pb-no-animate .pb-fill-skeleton {
+  transition: none;
+  animation: none;
+}
+
+.pb.pb-no-animate .pb-fill.pb-fill-indeterminate {
+  transform: translateX(0);
+  width: 100%;
+}
+
+.pb-fill.pb-fill-striped {
+  background-image: linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.15) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(255, 255, 255, 0.15) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-size: 1rem 1rem;
+}
+
+.pb.pb-animated .pb-fill.pb-fill-striped {
+  animation: pb-stripes 1.2s linear infinite;
+}
+
+.pb-segments {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.pb-segment {
+  flex: 0 0 auto;
+  height: 100%;
+  transition: flex-basis var(--pb-dur) var(--pb-ease), background-color var(--pb-dur) var(--pb-ease);
+  min-width: 0;
+}
+
+.pb-segment-status-default {
+  background-color: $blue-600;
+}
+
+.pb-segment-status-success {
+  background-color: $green-600;
+}
+
+.pb-segment-status-error {
+  background-color: $red-600;
+}
+
+.pb-segment-status-neutral {
+  background-color: $neutral-400;
+}
+
+.pb.pb-skeleton .pb-track {
+  background: $neutral-200;
+}
+
+.pb.pb-skeleton .pb-segment {
+  background: linear-gradient(
+    90deg,
+    $neutral-200 0%,
+    $neutral-300 50%,
+    $neutral-200 100%
+  );
+  animation: pb-shimmer 1.5s infinite;
+}
+
+.pb.pb-skeleton .pb-status-icon,
+.pb.pb-skeleton .pb-percentage {
+  color: $neutral-400;
+}
+
+.pb-item-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.pb-item-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 120px;
+  color: $neutral-600;
+  font-size: 0.75rem;
+}
+
+.pb-item-label-text {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.pb-item-icon {
+  font-size: 0.75rem;
+  color: inherit;
+}
+
+.pb-item-label-value {
+  font-weight: 600;
+}
+
+.pb.pb-stacked-labels .pb-item-labels {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.pb-helper {
+  margin: 0;
+  font-size: var(--pb-helper-size);
+  color: var(--pb-helper-color);
+}
+
+.pb.pb-status-error .pb-helper {
+  color: $red-600;
+}
+
+.pb.pb-status-success .pb-helper {
+  color: $green-600;
+}
+
+.pb.pb-status-neutral .pb-helper {
+  color: $neutral-500;
+}
+
+.pb-item-host {
+  display: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pb.pb-inline {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-auto-rows: auto;
+  column-gap: 0.75rem;
+  row-gap: 0.5rem;
+  align-items: center;
+}
+
+.pb.pb-inline .pb-main {
+  display: contents;
+}
+
+.pb.pb-inline .pb-header {
+  display: contents;
+}
+
+.pb.pb-inline .pb-header-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.pb.pb-inline .pb-percentage {
+  grid-column: 3;
+  grid-row: 1;
+  justify-self: end;
+}
+
+.pb.pb-inline .pb-track {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.pb.pb-inline .pb-helper,
+.pb.pb-inline .pb-item-labels,
+.pb.pb-inline .pb-segment-list {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 480px) {
+  .pb {
+    row-gap: 0.5rem;
+  }
+
+  .pb-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .pb.pb-inline {
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+  }
+
+  .pb.pb-inline .pb-percentage {
+    justify-self: start;
+  }
+
+  .pb-item-labels {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  .pb-helper {
+    white-space: normal;
+  }
+}
+
+@keyframes pb-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(30%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes pb-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@keyframes pb-stripes {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 1rem 0;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.component.ts
@@ -1,0 +1,333 @@
+import {
+  AfterContentChecked,
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  QueryList,
+  SimpleChanges,
+} from '@angular/core';
+import { CommonModule, NgClass, NgTemplateOutlet } from '@angular/common';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+import { ProgressBarItemComponent, ProgressBarItemStatus } from './progress-bar-item.component';
+
+type ProgressBarStatus = 'default' | 'success' | 'error' | 'neutral';
+
+interface ProgressBarSegment {
+  label?: string;
+  value: number;
+  percent: number;
+  status: ProgressBarItemStatus;
+  tooltip?: string;
+  icon?: string;
+  ariaLabel?: string;
+}
+
+@Component({
+  selector: 'app-progress-bar',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgTemplateOutlet],
+  templateUrl: './progress-bar.component.html',
+  styleUrls: ['./progress-bar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressBarComponent
+  implements OnChanges, AfterContentInit, AfterContentChecked, OnDestroy
+{
+  private static nextId = 0;
+
+  private readonly percentChanges$ = new Subject<number>();
+  private percentChangesSub?: Subscription;
+  private itemsChangesSub?: Subscription;
+
+  private lastPercent?: number;
+  private completedEmitted = false;
+  private itemsSignature: string | null = null;
+  private normalizationWarned = false;
+
+  readonly id = `app-progress-bar-${ProgressBarComponent.nextId++}`;
+  readonly labelId = `${this.id}-label`;
+  readonly helperId = `${this.id}-helper`;
+  readonly liveRegionId = `${this.id}-live`;
+
+  @Input() value: number | null | undefined = 0;
+  @Input() max: number = 100;
+  @Input() indeterminate: boolean = false;
+  @Input() label?: string;
+  @Input() helperText?: string;
+  @Input() status: ProgressBarStatus = 'default';
+  @Input() showPercentage: boolean = false;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() inline: boolean = false;
+  @Input() skeleton: boolean = false;
+  @Input() ariaLabel?: string;
+  @Input() ariaDescribedby?: string;
+  @Input() animated: boolean = true;
+  @Input() striped: boolean = false;
+  @Input() segmented: boolean = false;
+  @Input() stackedLabels: boolean = false;
+  @Input() showItemLabels: boolean = false;
+
+  @Output() readonly completed = new EventEmitter<void>();
+
+  @ContentChildren(ProgressBarItemComponent)
+  items?: QueryList<ProgressBarItemComponent>;
+
+  percent?: number;
+  currentValue: number = 0;
+  liveMessage: string = '';
+  segments: ProgressBarSegment[] = [];
+
+  constructor(private readonly cdr: ChangeDetectorRef) {
+    this.percentChangesSub = this.percentChanges$
+      .pipe(debounceTime(200), distinctUntilChanged())
+      .subscribe((percent) => {
+        this.liveMessage = `Progresso: ${Math.round(percent)}%`;
+        this.cdr.markForCheck();
+      });
+  }
+
+  @HostBinding('class')
+  get hostClasses(): string {
+    const classes = ['pb-host', `pb-size-${this.size}`, `pb-status-${this.status}`];
+    if (this.inline) {
+      classes.push('pb-inline');
+    }
+    if (this.segmented) {
+      classes.push('pb-segmented');
+    }
+    if (this.skeleton) {
+      classes.push('pb-skeleton');
+    }
+    if (this.indeterminate) {
+      classes.push('pb-indeterminate');
+    }
+    return classes.join(' ');
+  }
+
+  get isDeterminate(): boolean {
+    return !this.indeterminate && !this.skeleton;
+  }
+
+  get ariaBusy(): string {
+    return this.indeterminate || this.skeleton ? 'true' : 'false';
+  }
+
+  get ariaValueMin(): string | null {
+    return this.isDeterminate ? '0' : null;
+  }
+
+  get ariaValueMax(): string | null {
+    return this.isDeterminate ? String(Math.max(this.max, 0)) : null;
+  }
+
+  get ariaValueNow(): string | null {
+    return this.isDeterminate ? String(this.currentValue) : null;
+  }
+
+  get ariaLabelAttr(): string | null {
+    return this.label ? null : this.ariaLabel ?? null;
+  }
+
+  get ariaLabelledby(): string | null {
+    return this.label ? this.labelId : null;
+  }
+
+  get ariaDescribedByAttr(): string | null {
+    const ids: string[] = [];
+    if (this.helperText) {
+      ids.push(this.helperId);
+    }
+    if (this.ariaDescribedby) {
+      ids.push(this.ariaDescribedby);
+    }
+    return ids.length ? ids.join(' ') : null;
+  }
+
+  get percentageText(): string {
+    return `${Math.round(this.percent ?? 0)}%`;
+  }
+
+  get percentStyle(): string | null {
+    return this.percent !== undefined ? `${this.percent}%` : null;
+  }
+
+  get statusIcon(): string | null {
+    if (this.status === 'success') {
+      return '✓';
+    }
+    if (this.status === 'error') {
+      return '⨯';
+    }
+    return null;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      'value' in changes ||
+      'max' in changes ||
+      'indeterminate' in changes ||
+      'skeleton' in changes
+    ) {
+      this.updateProgress();
+    }
+
+    if ('segmented' in changes || 'max' in changes) {
+      this.resetSegments();
+      this.recalculateSegments();
+    }
+  }
+
+  ngAfterContentInit(): void {
+    if (this.items) {
+      this.itemsChangesSub = this.items.changes.subscribe(() => {
+        this.resetSegments();
+        this.recalculateSegments();
+      });
+    }
+    this.recalculateSegments();
+  }
+
+  ngAfterContentChecked(): void {
+    if (this.segmented) {
+      const signature = this.buildItemsSignature();
+      if (signature !== this.itemsSignature) {
+        this.itemsSignature = signature;
+        this.recalculateSegments();
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.percentChangesSub?.unsubscribe();
+    this.itemsChangesSub?.unsubscribe();
+  }
+
+  private updateProgress(): void {
+    const max = Math.max(this.max, 0);
+    const rawValue = this.value ?? 0;
+    const clampedValue = max > 0 ? this.clamp(rawValue, 0, max) : 0;
+
+    this.currentValue = clampedValue;
+
+    if (this.isDeterminate && max > 0) {
+      const percent = this.clamp((clampedValue / max) * 100, 0, 100);
+      this.percent = percent;
+      if (percent !== this.lastPercent) {
+        this.lastPercent = percent;
+        this.percentChanges$.next(percent);
+      }
+      if (percent >= 100) {
+        if (!this.completedEmitted) {
+          this.completed.emit();
+          this.completedEmitted = true;
+        }
+      } else {
+        this.completedEmitted = false;
+      }
+    } else {
+      this.percent = undefined;
+      this.lastPercent = undefined;
+      this.liveMessage = '';
+      this.completedEmitted = false;
+    }
+  }
+
+  private recalculateSegments(): void {
+    if (!this.segmented) {
+      if (this.segments.length) {
+        this.segments = [];
+        this.cdr.markForCheck();
+      }
+      return;
+    }
+
+    const items = this.items?.toArray() ?? [];
+    if (!items.length) {
+      if (this.segments.length) {
+        this.segments = [];
+        this.cdr.markForCheck();
+      }
+      return;
+    }
+
+    const max = Math.max(this.max, 0);
+    const safeMax = max > 0 ? max : 0;
+    const sanitized = items.map((item) => ({
+      label: item.label,
+      value: Math.max(item.value, 0),
+      status: item.status ?? 'default',
+      tooltip: item.tooltip,
+      icon: item.icon,
+      ariaLabel: item.ariaLabel,
+    }));
+
+    const total = sanitized.reduce((sum, item) => sum + item.value, 0);
+    let factor = 1;
+    if (safeMax > 0 && total > safeMax) {
+      factor = safeMax / total;
+      if (!this.normalizationWarned) {
+        console.warn(
+          '[ProgressBarComponent] Segment values exceed max. Values will be normalized.'
+        );
+        this.normalizationWarned = true;
+      }
+    } else {
+      this.normalizationWarned = false;
+    }
+
+    const computed: ProgressBarSegment[] = sanitized.map((item) => {
+      const normalizedValue = item.value * factor;
+      const percent = safeMax > 0 ? this.clamp((normalizedValue / safeMax) * 100, 0, 100) : 0;
+      return {
+        label: item.label,
+        value: normalizedValue,
+        percent,
+        status: item.status,
+        tooltip: item.tooltip,
+        icon: item.icon,
+        ariaLabel: item.ariaLabel,
+      };
+    });
+
+    this.segments = computed;
+    this.cdr.markForCheck();
+  }
+
+  private resetSegments(): void {
+    this.itemsSignature = null;
+    this.normalizationWarned = false;
+  }
+
+  private buildItemsSignature(): string {
+    if (!this.items || !this.items.length) {
+      return '';
+    }
+
+    return this.items
+      .map((item) =>
+        [
+          item.label ?? '',
+          item.value,
+          item.status ?? 'default',
+          item.tooltip ?? '',
+          item.icon ?? '',
+          item.ariaLabel ?? '',
+        ].join('|')
+      )
+      .join(';');
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.mocks.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.mocks.ts
@@ -1,0 +1,48 @@
+import { ProgressBarItemStatus } from './progress-bar-item.component';
+
+export interface ProgressBarSegmentMock {
+  label: string;
+  value: number;
+  status?: ProgressBarItemStatus;
+  tooltip?: string;
+  icon?: string;
+}
+
+export const PROGRESS_BAR_DETERMINATE_MOCK = {
+  value: 72,
+  max: 100,
+  label: 'Progress bar label',
+  helperText: 'Optional helper text',
+  showPercentage: true,
+};
+
+export const PROGRESS_BAR_INDETERMINATE_MOCK = {
+  indeterminate: true,
+  label: 'Carregando dados...',
+  helperText: 'Isso pode levar alguns segundos',
+};
+
+export const PROGRESS_BAR_SUCCESS_MOCK = {
+  value: 100,
+  max: 100,
+  status: 'success' as const,
+  label: 'Upload concluído',
+  helperText: 'Success message text',
+  showPercentage: true,
+};
+
+export const PROGRESS_BAR_ERROR_MOCK = {
+  value: 100,
+  max: 100,
+  status: 'error' as const,
+  label: 'Falha ao enviar',
+  helperText: 'Error message text',
+  showPercentage: true,
+};
+
+export const PROGRESS_BAR_SEGMENTED_MOCK: ProgressBarSegmentMock[] = [
+  { label: 'Baixando', value: 20, status: 'default' },
+  { label: 'Processando', value: 40, status: 'default' },
+  { label: 'Validando', value: 25, status: 'success' },
+  { label: 'Publicando', value: 15, status: 'neutral' },
+];

--- a/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.stories.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-bar/progress-bar.stories.ts
@@ -1,0 +1,231 @@
+import { CommonModule } from '@angular/common';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import { provideAnimations } from '@angular/platform-browser/animations';
+
+import { ProgressBarComponent } from './progress-bar.component';
+import { ProgressBarItemComponent } from './progress-bar-item.component';
+import {
+  PROGRESS_BAR_DETERMINATE_MOCK,
+  PROGRESS_BAR_ERROR_MOCK,
+  PROGRESS_BAR_INDETERMINATE_MOCK,
+  PROGRESS_BAR_SEGMENTED_MOCK,
+  PROGRESS_BAR_SUCCESS_MOCK,
+} from './progress-bar.mocks';
+
+const meta: Meta<ProgressBarComponent> = {
+  title: 'Shared/Components/Progress Bar',
+  component: ProgressBarComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideAnimations()],
+    }),
+  ],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['default', 'success', 'error', 'neutral'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    showPercentage: { control: 'boolean' },
+    inline: { control: 'boolean' },
+    skeleton: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    segmented: { control: 'boolean' },
+    striped: { control: 'boolean' },
+    animated: { control: 'boolean' },
+    stackedLabels: { control: 'boolean' },
+    showItemLabels: { control: 'boolean' },
+    completed: { action: 'completed' },
+  },
+  args: {
+    max: 100,
+    status: 'default',
+    size: 'md',
+    showPercentage: false,
+    inline: false,
+    skeleton: false,
+    indeterminate: false,
+    segmented: false,
+    striped: false,
+    animated: true,
+    stackedLabels: false,
+    showItemLabels: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ProgressBarComponent>;
+
+const baseRender: Story['render'] = (args) => ({
+  props: args,
+  template: `
+    <app-progress-bar
+      [value]="value"
+      [max]="max"
+      [indeterminate]="indeterminate"
+      [label]="label"
+      [helperText]="helperText"
+      [status]="status"
+      [showPercentage]="showPercentage"
+      [size]="size"
+      [inline]="inline"
+      [skeleton]="skeleton"
+      [ariaLabel]="ariaLabel"
+      [ariaDescribedby]="ariaDescribedby"
+      [animated]="animated"
+      [striped]="striped"
+      [segmented]="segmented"
+      [stackedLabels]="stackedLabels"
+      [showItemLabels]="showItemLabels"
+    ></app-progress-bar>
+  `,
+  imports: [ProgressBarComponent],
+});
+
+export const Determinate: Story = {
+  render: baseRender,
+  args: {
+    ...PROGRESS_BAR_DETERMINATE_MOCK,
+  },
+};
+
+export const Empty: Story = {
+  render: baseRender,
+  args: {
+    label: 'Sem progresso',
+    helperText: 'Nenhum item iniciado ainda',
+    value: 0,
+    showPercentage: true,
+  },
+};
+
+export const Quarter: Story = {
+  render: baseRender,
+  args: {
+    label: 'Progresso 25%',
+    helperText: 'Primeira fase concluída',
+    value: 25,
+    showPercentage: true,
+  },
+};
+
+export const Half: Story = {
+  render: baseRender,
+  args: {
+    label: 'Progresso 50%',
+    helperText: 'Metade do caminho',
+    value: 50,
+    showPercentage: true,
+  },
+};
+
+export const ThreeQuarters: Story = {
+  render: baseRender,
+  args: {
+    label: 'Progresso 75%',
+    helperText: 'Quase lá',
+    value: 75,
+    showPercentage: true,
+  },
+};
+
+export const Full: Story = {
+  render: baseRender,
+  args: {
+    label: 'Progresso completo',
+    helperText: 'Todas as etapas finalizadas',
+    value: 100,
+    showPercentage: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  render: baseRender,
+  args: {
+    ...PROGRESS_BAR_INDETERMINATE_MOCK,
+  },
+};
+
+export const Success: Story = {
+  render: baseRender,
+  args: {
+    ...PROGRESS_BAR_SUCCESS_MOCK,
+  },
+};
+
+export const Error: Story = {
+  render: baseRender,
+  args: {
+    ...PROGRESS_BAR_ERROR_MOCK,
+  },
+};
+
+export const Inline: Story = {
+  render: baseRender,
+  args: {
+    label: 'Etapa atual',
+    helperText: 'Processando lote 2 de 5',
+    value: 45,
+    showPercentage: true,
+    inline: true,
+  },
+};
+
+export const Skeleton: Story = {
+  render: baseRender,
+  args: {
+    label: 'Carregando progresso',
+    skeleton: true,
+  },
+};
+
+export const Segmented: Story = {
+  render: (args) => ({
+    props: { ...args, segments: PROGRESS_BAR_SEGMENTED_MOCK },
+    template: `
+      <app-progress-bar
+        [max]="max"
+        [label]="label"
+        [helperText]="helperText"
+        [segmented]="segmented"
+        [showItemLabels]="showItemLabels"
+        [stackedLabels]="stackedLabels"
+      >
+        <app-progress-bar-item
+          *ngFor="let item of segments"
+          [label]="item.label"
+          [value]="item.value"
+          [status]="item.status"
+        ></app-progress-bar-item>
+      </app-progress-bar>
+    `,
+    imports: [CommonModule, ProgressBarComponent, ProgressBarItemComponent],
+  }),
+  args: {
+    max: 100,
+    label: 'Pipeline',
+    helperText: 'Monitorando cada etapa',
+    segmented: true,
+    showItemLabels: true,
+    stackedLabels: false,
+  },
+};
+
+export const Responsive: Story = {
+  render: baseRender,
+  args: {
+    label: 'Progresso responsivo',
+    helperText: 'Redimensione a viewport para testar',
+    value: 60,
+    showPercentage: true,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- implement standalone progress bar with determinate, indeterminate, skeleton, inline, and segmented modes plus aria live announcements
- add companion progress bar item component, styling, and example mocks following Carbon-inspired tokens
- document the progress bar in Storybook with comprehensive stories for key states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d2c5e4548331b00603c83800752a