### PR TITLE
feat: add progress indicator components

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.html
@@ -1,0 +1,97 @@
+<div
+  class="progress-indicator-item"
+  [ngClass]="[
+    'orientation-' + orientation,
+    'size-' + size,
+    'state-' + state,
+    isCurrent ? 'is-current' : '',
+    isComplete ? 'is-complete' : '',
+    isError ? 'is-error' : '',
+    isDisabledState ? 'is-disabled' : '',
+    skeleton ? 'is-skeleton' : '',
+    tooltipVisible ? 'tooltip-open' : ''
+  ]"
+  role="listitem"
+  [attr.aria-setsize]="total || null"
+  [attr.aria-posinset]="position || null"
+  [class.is-clickable]="clickable && !isDisabledState && !skeleton"
+>
+  <div
+    #interactive
+    class="progress-indicator-item__interactive"
+    [attr.id]="itemId"
+    [attr.role]="interactiveRole"
+    [attr.tabindex]="tabIndex"
+    [attr.aria-current]="isCurrent ? 'step' : null"
+    [attr.aria-disabled]="ariaDisabled"
+    [attr.aria-describedby]="tooltip ? tooltipId : null"
+    (click)="onClick($event)"
+    (keydown)="onKeydown($event)"
+    (focus)="onFocus()"
+    (blur)="onBlur()"
+    (mouseenter)="onMouseEnter()"
+    (mouseleave)="onMouseLeave()"
+  >
+    <span
+      class="progress-indicator-item__connector progress-indicator-item__connector--before"
+      aria-hidden="true"
+      [class.is-hidden]="isFirst"
+    ></span>
+    <span class="progress-indicator-item__bullet" aria-hidden="true">
+      <span class="progress-indicator-item__bullet-inner" *ngIf="!skeleton">
+        <svg
+          *ngIf="isComplete"
+          class="progress-indicator-item__icon"
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          focusable="false"
+          aria-hidden="true"
+        >
+          <path
+            d="M6.4 10.6 3.8 8l-1.1 1.1L6.4 12l7-7-1.1-1.1z"
+            fill="currentColor"
+          ></path>
+        </svg>
+        <svg
+          *ngIf="isError"
+          class="progress-indicator-item__icon"
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          focusable="false"
+          aria-hidden="true"
+        >
+          <path
+            d="M7.3 2.3 1.4 13a1 1 0 0 0 .9 1.5h11.4a1 1 0 0 0 .9-1.5L8.7 2.3a1 1 0 0 0-1.4 0Zm.7 3.2a.7.7 0 0 1 .7.7v3.4a.7.7 0 0 1-1.4 0V6.2a.7.7 0 0 1 .7-.7Zm0 6.5a.8.8 0 1 1 0 1.5.8.8 0 0 1 0-1.5Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </span>
+      <span class="progress-indicator-item__bullet-skeleton" *ngIf="skeleton"></span>
+    </span>
+    <span
+      class="progress-indicator-item__connector progress-indicator-item__connector--after"
+      aria-hidden="true"
+      [class.is-hidden]="isLast"
+    ></span>
+  </div>
+
+  <div class="progress-indicator-item__labels" *ngIf="showLabels && !skeleton">
+    <span class="progress-indicator-item__label">{{ label }}</span>
+    <span class="progress-indicator-item__optional" *ngIf="optionalLabel">{{ optionalLabel }}</span>
+  </div>
+
+  <div class="progress-indicator-item__skeleton-label" *ngIf="skeleton && showLabels" aria-hidden="true"></div>
+
+  <div
+    class="progress-indicator-item__tooltip"
+    *ngIf="tooltip"
+    [id]="tooltipId"
+    role="tooltip"
+    [class.is-visible]="tooltipVisible"
+    [attr.aria-hidden]="tooltipVisible ? 'false' : 'true'"
+  >
+    <span class="progress-indicator-item__tooltip-text">{{ tooltip }}</span>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.scss
@@ -1,0 +1,309 @@
+@import "../../general/colors/colors.scss";
+
+:host {
+  display: block;
+}
+
+.progress-indicator-item {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: $neutral-700;
+  transition: color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+
+  &.orientation-horizontal {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+  }
+
+  &.orientation-vertical {
+    flex-direction: row;
+    align-items: flex-start;
+    text-align: left;
+    gap: 0.75rem;
+  }
+
+  &__interactive {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border-radius: 999px;
+    outline: none;
+    transition: box-shadow 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+    cursor: default;
+    gap: 0.5rem;
+    background-color: transparent;
+  }
+
+  &.is-clickable &__interactive {
+    cursor: pointer;
+  }
+
+  &.is-disabled &__interactive,
+  &.is-skeleton &__interactive,
+  &__interactive[aria-disabled='true'] {
+    cursor: default;
+  }
+
+  &__interactive:focus-visible {
+    box-shadow: 0 0 0 2px $neutral-50, 0 0 0 4px $blue-600;
+  }
+
+  &.orientation-horizontal &__interactive {
+    min-width: calc(var(--pi-bullet-size) + 0.75rem);
+    min-height: calc(var(--pi-bullet-size) + 0.75rem);
+    width: 100%;
+  }
+
+  &.orientation-vertical &__interactive {
+    flex-direction: column;
+    min-height: calc(var(--pi-bullet-size) + 0.75rem);
+    gap: 0.5rem;
+  }
+
+  &__connector {
+    background-color: $neutral-200;
+    transition: background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+    border-radius: 999px;
+  }
+
+  &.orientation-horizontal &__connector {
+    flex: 1 1 auto;
+    height: var(--pi-connector);
+  }
+
+  &.orientation-vertical &__connector {
+    width: var(--pi-connector);
+    min-height: 0.75rem;
+    flex: 1 1 auto;
+  }
+
+  &__connector.is-hidden {
+    visibility: hidden;
+  }
+
+  &__bullet {
+    width: var(--pi-bullet-size);
+    height: var(--pi-bullet-size);
+    border-radius: 50%;
+    border: 2px solid $neutral-300;
+    background-color: $neutral-50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    color: $neutral-50;
+    transition: border-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      box-shadow 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  }
+
+  &__bullet-inner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__icon {
+    display: block;
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  &__labels {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    max-width: 10rem;
+  }
+
+  &.orientation-horizontal &__labels {
+    align-items: center;
+  }
+
+  &.orientation-vertical &__labels {
+    align-items: flex-start;
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: inherit;
+    transition: color 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      text-decoration-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  }
+
+  &__optional {
+    font-size: 0.75rem;
+    color: $neutral-600;
+  }
+
+  &.is-current &__label {
+    color: $blue-600;
+  }
+
+  &.is-error &__label {
+    color: $red-600;
+  }
+
+  &.is-disabled &__label,
+  &.is-disabled &__optional {
+    color: $neutral-500;
+  }
+
+  &.is-clickable &__interactive:hover ~ &__labels .progress-indicator-item__label {
+    text-decoration: underline;
+  }
+
+  &.is-clickable &__interactive:hover .progress-indicator-item__bullet {
+    border-color: $blue-600;
+  }
+
+  &.is-disabled &__interactive:hover ~ &__labels .progress-indicator-item__label,
+  &.is-skeleton &__interactive:hover ~ &__labels .progress-indicator-item__label {
+    text-decoration: none;
+  }
+
+  &.is-disabled &__interactive:hover .progress-indicator-item__bullet,
+  &.is-skeleton &__interactive:hover .progress-indicator-item__bullet {
+    border-color: $neutral-300;
+  }
+
+  &__tooltip {
+    position: absolute;
+    max-width: 14rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.25rem;
+    background-color: $neutral-800;
+    color: $neutral-50;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    box-shadow: 0 4px 12px rgba($neutral-900, 0.2);
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, -0.5rem);
+    transition: opacity 150ms cubic-bezier(0.2, 0, 0.38, 0.9),
+      transform 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+    z-index: 10;
+    left: 50%;
+    top: 100%;
+  }
+
+  &.orientation-vertical &__tooltip {
+    left: calc(var(--pi-bullet-size) + 1.5rem);
+    top: 50%;
+    transform: translate(0, -50%);
+  }
+
+  &__tooltip::after {
+    content: "";
+    position: absolute;
+    width: 0.5rem;
+    height: 0.5rem;
+    background-color: $neutral-800;
+    transform: rotate(45deg);
+    left: 50%;
+    top: -0.25rem;
+    margin-left: -0.25rem;
+  }
+
+  &.orientation-vertical &__tooltip::after {
+    left: -0.25rem;
+    top: 50%;
+    margin-top: -0.25rem;
+  }
+
+  &__tooltip.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
+  }
+
+  &.orientation-vertical &__tooltip.is-visible {
+    transform: translate(0, -50%);
+  }
+
+  &__tooltip-text {
+    display: block;
+  }
+
+  &.is-current &__bullet {
+    border-color: $blue-600;
+  }
+
+  &.is-current &__bullet::after {
+    content: "";
+    position: absolute;
+    width: calc(var(--pi-bullet-size) / 2);
+    height: calc(var(--pi-bullet-size) / 2);
+    border-radius: 50%;
+    background-color: $blue-600;
+  }
+
+  &.is-complete &__bullet {
+    background-color: $blue-600;
+    border-color: $blue-600;
+    color: $neutral-50;
+  }
+
+  &.is-error &__bullet {
+    background-color: $red-600;
+    border-color: $red-600;
+    color: $neutral-50;
+  }
+
+  &.is-complete &__connector,
+  &.is-current &__connector--before {
+    background-color: $blue-600;
+  }
+
+  &.is-error &__connector--before {
+    background-color: $red-600;
+  }
+
+  &.is-disabled {
+    opacity: 0.6;
+  }
+
+  &.is-skeleton {
+    color: $neutral-500;
+  }
+
+  &__bullet-skeleton {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: $neutral-200;
+    animation: progress-skeleton 1.6s ease-in-out infinite;
+  }
+
+  &__skeleton-label {
+    width: 5rem;
+    height: 0.75rem;
+    border-radius: 999px;
+    background-color: $neutral-200;
+    animation: progress-skeleton 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes progress-skeleton {
+  0% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0.45;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator-item/progress-indicator-item.component.ts
@@ -1,0 +1,152 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule, NgClass, NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-progress-indicator-item',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgIf],
+  templateUrl: './progress-indicator-item.component.html',
+  styleUrl: './progress-indicator-item.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressIndicatorItemComponent {
+  private static nextId = 0;
+
+  @Input() index = 0;
+  @Input() label = '';
+  @Input() optionalLabel?: string;
+  @Input() state: 'incomplete' | 'current' | 'complete' | 'error' | 'disabled' = 'incomplete';
+  @Input() tooltip?: string;
+  @Input() size: 'sm' | 'md' = 'md';
+  @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @Input() clickable = true;
+  @Input() skeleton = false;
+  @Input() showLabels = true;
+  @Input() isFirst = false;
+  @Input() isLast = false;
+  @Input() tabStop = false;
+  @Input() itemId: string = `app-progress-indicator-item-${ProgressIndicatorItemComponent.nextId++}`;
+  @Input() tooltipId?: string;
+  @Input() total = 0;
+  @Input() position = 0;
+  @Input() href?: string;
+
+  @Output() readonly activate = new EventEmitter<void>();
+  @Output() readonly focused = new EventEmitter<void>();
+
+  @ViewChild('interactive', { static: true })
+  private readonly interactive?: ElementRef<HTMLElement>;
+
+  tooltipVisible = false;
+
+  constructor(private readonly cdr: ChangeDetectorRef) {}
+
+  get isDisabledState(): boolean {
+    return this.state === 'disabled' || this.skeleton;
+  }
+
+  get isCurrent(): boolean {
+    return this.state === 'current';
+  }
+
+  get isComplete(): boolean {
+    return this.state === 'complete';
+  }
+
+  get isError(): boolean {
+    return this.state === 'error';
+  }
+
+  get interactiveRole(): string | null {
+    if (this.skeleton) {
+      return null;
+    }
+    return this.clickable ? 'button' : null;
+  }
+
+  get ariaDisabled(): string | null {
+    return this.isDisabledState ? 'true' : null;
+  }
+
+  get tabIndex(): number {
+    if (this.isDisabledState) {
+      return -1;
+    }
+    return this.tabStop ? 0 : -1;
+  }
+
+  focus(): void {
+    if (!this.interactive) {
+      return;
+    }
+    this.interactive.nativeElement.focus({ preventScroll: true });
+  }
+
+  onClick(event: MouseEvent): void {
+    if (!this.canActivate()) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.activate.emit();
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (this.canActivate()) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.activate.emit();
+      }
+    } else if (event.key === 'Escape' && this.tooltipVisible) {
+      this.hideTooltip();
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  }
+
+  onFocus(): void {
+    this.focused.emit();
+    if (this.tooltip && !this.skeleton && !this.isDisabledState) {
+      this.tooltipVisible = true;
+      this.cdr.markForCheck();
+    }
+  }
+
+  onBlur(): void {
+    if (this.tooltipVisible) {
+      this.hideTooltip();
+    }
+  }
+
+  onMouseEnter(): void {
+    if (this.tooltip && !this.skeleton && !this.isDisabledState) {
+      this.tooltipVisible = true;
+      this.cdr.markForCheck();
+    }
+  }
+
+  onMouseLeave(): void {
+    if (this.tooltipVisible) {
+      this.hideTooltip();
+    }
+  }
+
+  hideTooltip(): void {
+    this.tooltipVisible = false;
+    this.cdr.markForCheck();
+  }
+
+  private canActivate(): boolean {
+    return this.clickable && !this.isDisabledState && !this.skeleton;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.html
@@ -1,0 +1,41 @@
+<div
+  class="progress-indicator"
+  [ngClass]="[
+    'orientation-' + orientation,
+    'size-' + size,
+    showLabels ? 'with-labels' : 'without-labels',
+    skeleton ? 'is-skeleton' : ''
+  ]"
+  role="list"
+  [attr.aria-label]="ariaLabel"
+  (keydown)="onKeydown($event)"
+>
+  <div class="progress-indicator__track" aria-hidden="true"></div>
+  <div class="progress-indicator__items">
+    <ng-container *ngFor="let item of renderedItems; let i = index; trackBy: trackByIndex">
+      <app-progress-indicator-item
+        [index]="i"
+        [label]="item.label"
+        [optionalLabel]="item.optionalLabel"
+        [state]="item.state || 'incomplete'"
+        [tooltip]="item.tooltip"
+        [href]="item.href"
+        [size]="size"
+        [orientation]="orientation"
+        [clickable]="clickable && !skeleton"
+        [skeleton]="skeleton"
+        [showLabels]="showLabels"
+        [isFirst]="i === 0"
+        [isLast]="i === renderedItems.length - 1"
+        [tabStop]="focusedIndex === i"
+        [itemId]="getItemId(i, item)"
+        [tooltipId]="getTooltipId(i, item) || undefined"
+        [total]="renderedItems.length"
+        [position]="i + 1"
+        (activate)="onItemActivate(i)"
+        (focused)="onItemFocus(i)"
+      ></app-progress-indicator-item>
+    </ng-container>
+  </div>
+  <div class="visually-hidden" [id]="liveRegionId" aria-live="polite">{{ liveMessage }}</div>
+</div>

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.scss
@@ -1,0 +1,130 @@
+@import "../../general/colors/colors.scss";
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+.progress-indicator {
+  --pi-bullet-size: 1rem;
+  --pi-connector: 2px;
+  --pi-gap-horizontal: 1.75rem;
+  --pi-gap-vertical: 1.25rem;
+
+  position: relative;
+  width: 100%;
+  color: $neutral-700;
+
+  &.size-sm {
+    --pi-bullet-size: 0.75rem;
+  }
+
+  &.size-md {
+    --pi-bullet-size: 1rem;
+  }
+
+  &__items {
+    position: relative;
+    display: flex;
+    gap: var(--pi-gap-horizontal);
+    z-index: 1;
+    width: 100%;
+  }
+
+  &__track {
+    position: absolute;
+    pointer-events: none;
+    background-color: $neutral-200;
+    border-radius: 999px;
+    z-index: 0;
+    transition: background-color 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  }
+
+  &.orientation-horizontal {
+    padding-top: calc(var(--pi-bullet-size) + 0.5rem);
+    padding-bottom: 0.25rem;
+
+    .progress-indicator__items {
+      align-items: flex-start;
+      justify-content: space-between;
+    }
+
+    .progress-indicator__items > * {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .progress-indicator__track {
+      top: calc(var(--pi-bullet-size) / 2);
+      left: calc(var(--pi-bullet-size) / 2);
+      right: calc(var(--pi-bullet-size) / 2);
+      height: var(--pi-connector);
+    }
+  }
+
+  &.orientation-horizontal.without-labels {
+    padding-top: calc(var(--pi-bullet-size) + 0.25rem);
+    padding-bottom: 0;
+  }
+
+  &.orientation-vertical {
+    padding-left: calc(var(--pi-bullet-size) + 1.5rem);
+
+    .progress-indicator__items {
+      flex-direction: column;
+      gap: var(--pi-gap-vertical);
+      align-items: stretch;
+    }
+
+    .progress-indicator__track {
+      top: calc(var(--pi-bullet-size) / 2);
+      bottom: calc(var(--pi-bullet-size) / 2);
+      left: calc(var(--pi-bullet-size) / 2);
+      width: var(--pi-connector);
+    }
+  }
+
+  &.is-skeleton {
+    .progress-indicator__track {
+      background-color: $neutral-200;
+    }
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+}
+
+@media (max-width: 480px) {
+  .progress-indicator.orientation-horizontal {
+    padding-left: calc(var(--pi-bullet-size) + 1.5rem);
+    padding-top: 0;
+
+    .progress-indicator__items {
+      flex-direction: column;
+      gap: var(--pi-gap-vertical);
+      align-items: stretch;
+    }
+
+    .progress-indicator__items > * {
+      flex: none;
+    }
+
+    .progress-indicator__track {
+      top: calc(var(--pi-bullet-size) / 2);
+      bottom: calc(var(--pi-bullet-size) / 2);
+      left: calc(var(--pi-bullet-size) / 2);
+      right: auto;
+      width: var(--pi-connector);
+      height: auto;
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.spec.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressIndicatorComponent } from './progress-indicator.component';
+import { ProgressItem } from './progress-indicator.component';
+
+function createKeyboardEvent(key: string): KeyboardEvent {
+  return {
+    key,
+    preventDefault: jasmine.createSpy('preventDefault'),
+    stopPropagation: jasmine.createSpy('stopPropagation'),
+  } as unknown as KeyboardEvent;
+}
+
+describe('ProgressIndicatorComponent', () => {
+  let component: ProgressIndicatorComponent;
+  let fixture: ComponentFixture<ProgressIndicatorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProgressIndicatorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgressIndicatorComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should move focus to the next enabled step on keyboard navigation', () => {
+    const items: ProgressItem[] = [
+      { label: 'Primeiro', state: 'complete' },
+      { label: 'Segundo', state: 'disabled' },
+      { label: 'Terceiro', state: 'incomplete' },
+    ];
+    component.items = items;
+    fixture.detectChanges();
+
+    const event = createKeyboardEvent('ArrowRight');
+    component.onKeydown(event);
+
+    expect(component.focusedIndex).toBe(2);
+    expect((event.preventDefault as jasmine.Spy)).toHaveBeenCalled();
+    expect((event.stopPropagation as jasmine.Spy)).toHaveBeenCalled();
+  });
+});

--- a/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/progress-indicator/progress-indicator.component.ts
@@ -1,0 +1,363 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  QueryList,
+  SimpleChanges,
+  ViewChildren,
+} from '@angular/core';
+import { CommonModule, NgClass, NgFor, NgIf } from '@angular/common';
+import { Subscription } from 'rxjs';
+
+import { ProgressIndicatorItemComponent } from '../progress-indicator-item/progress-indicator-item.component';
+
+export interface ProgressItem {
+  id?: string;
+  label: string;
+  optionalLabel?: string;
+  state?: 'incomplete' | 'current' | 'complete' | 'error' | 'disabled';
+  tooltip?: string;
+  href?: string;
+}
+
+@Component({
+  selector: 'app-progress-indicator',
+  standalone: true,
+  imports: [CommonModule, NgClass, NgFor, NgIf, ProgressIndicatorItemComponent],
+  templateUrl: './progress-indicator.component.html',
+  styleUrl: './progress-indicator.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressIndicatorComponent implements OnChanges, AfterViewInit, OnDestroy {
+  private static nextId = 0;
+
+  @HostBinding('attr.role') readonly role = 'presentation';
+
+  private viewChangesSub?: Subscription;
+
+  private _items: ProgressItem[] = [];
+
+  readonly id = `app-progress-indicator-${ProgressIndicatorComponent.nextId++}`;
+  readonly liveRegionId = `${this.id}-live-region`;
+
+  /** Resolved ids for each step to keep aria-describedby stable between renders. */
+  private readonly itemIds = new Map<number, string>();
+
+  /** Indicates which index currently owns the roving tabindex. */
+  focusedIndex = 0;
+
+  /** Accessible feedback describing the current step. */
+  liveMessage = '';
+
+  @Input()
+  get items(): ProgressItem[] {
+    return this._items;
+  }
+  set items(value: ProgressItem[] | null | undefined) {
+    this._items = Array.isArray(value) ? value : [];
+    this.rebuildItemIds();
+    this.syncCurrentIndex();
+  }
+
+  @Input() currentIndex = 0;
+  @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @Input() size: 'sm' | 'md' = 'md';
+  @Input() clickable = true;
+  @Input() showLabels = true;
+  @Input() skeleton = false;
+  @Input() ariaLabel = 'Progress indicator';
+
+  @Output() readonly stepChange = new EventEmitter<number>();
+  @Output() readonly stepActivate = new EventEmitter<ProgressItem>();
+  @Output() readonly stepFocus = new EventEmitter<number>();
+
+  @ViewChildren(ProgressIndicatorItemComponent)
+  private readonly itemComponents?: QueryList<ProgressIndicatorItemComponent>;
+
+  constructor(private readonly cdr: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['currentIndex']) {
+      this.syncCurrentIndex();
+    }
+
+    if (changes['orientation']) {
+      this.ensureFocusVisibility();
+    }
+
+    if (changes['skeleton']) {
+      this.ensureFocusVisibility();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.viewChangesSub = this.itemComponents?.changes.subscribe(() => {
+      this.ensureFocusVisibility();
+    });
+    this.ensureFocusVisibility();
+  }
+
+  ngOnDestroy(): void {
+    this.viewChangesSub?.unsubscribe();
+  }
+
+  get isVertical(): boolean {
+    return this.orientation === 'vertical';
+  }
+
+  get itemCount(): number {
+    return this._items.length;
+  }
+
+  get renderedItems(): ProgressItem[] {
+    if (this.skeleton) {
+      const count = this._items.length > 0 ? this._items.length : 4;
+      return Array.from({ length: count }, (_, index) => ({
+        id: `${this.id}-skeleton-${index}`,
+        label: '',
+        optionalLabel: '',
+        state: 'incomplete',
+      }));
+    }
+    return this._items;
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  onItemActivate(index: number): void {
+    if (this.skeleton) {
+      return;
+    }
+
+    const item = this._items[index];
+    if (!item || this.isDisabled(index)) {
+      return;
+    }
+
+    if (this.focusedIndex !== index) {
+      this.focusedIndex = index;
+      this.stepFocus.emit(index);
+    }
+
+    if (this.clickable) {
+      if (this.currentIndex !== index) {
+        this.currentIndex = index;
+        this.updateLiveMessage();
+      }
+      this.stepChange.emit(index);
+    }
+
+    this.stepActivate.emit(item);
+    this.cdr.markForCheck();
+  }
+
+  onItemFocus(index: number): void {
+    if (this.focusedIndex !== index) {
+      this.focusedIndex = index;
+      this.stepFocus.emit(index);
+      this.cdr.markForCheck();
+    }
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (this.skeleton || this.itemCount === 0) {
+      return;
+    }
+
+    const horizontal = this.orientation === 'horizontal';
+    const key = event.key;
+    let handled = false;
+
+    if (horizontal) {
+      if (key === 'ArrowRight') {
+        handled = this.moveFocus(1);
+      } else if (key === 'ArrowLeft') {
+        handled = this.moveFocus(-1);
+      }
+    } else {
+      if (key === 'ArrowDown') {
+        handled = this.moveFocus(1);
+      } else if (key === 'ArrowUp') {
+        handled = this.moveFocus(-1);
+      }
+    }
+
+    if (key === 'Home') {
+      handled = this.focusEdge(true);
+    } else if (key === 'End') {
+      handled = this.focusEdge(false);
+    } else if (key === 'Enter' || key === ' ') {
+      if (!this.isDisabled(this.focusedIndex) && this.clickable) {
+        this.onItemActivate(this.focusedIndex);
+        handled = true;
+      }
+    } else if (key === 'Escape') {
+      handled = true; // Esc closes tooltips via child listeners but prevent other effects
+    }
+
+    if (handled) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  isDisabled(index: number): boolean {
+    if (this.skeleton) {
+      return true;
+    }
+    const item = this._items[index];
+    return !item || item.state === 'disabled';
+  }
+
+  getItemId(index: number, item: ProgressItem): string {
+    if (item.id) {
+      return item.id;
+    }
+    const existing = this.itemIds.get(index);
+    if (existing) {
+      return existing;
+    }
+    const generated = `${this.id}-step-${index}`;
+    this.itemIds.set(index, generated);
+    return generated;
+  }
+
+  getTooltipId(index: number, item: ProgressItem): string | null {
+    if (!item.tooltip) {
+      return null;
+    }
+    return `${this.getItemId(index, item)}-tooltip`;
+  }
+
+  private rebuildItemIds(): void {
+    this.itemIds.clear();
+    this._items.forEach((item, index) => {
+      if (item.id) {
+        this.itemIds.set(index, item.id);
+      }
+    });
+    this.ensureFocusVisibility();
+    this.updateLiveMessage();
+  }
+
+  private syncCurrentIndex(): void {
+    if (!this._items.length) {
+      this.currentIndex = 0;
+      this.focusedIndex = 0;
+      this.liveMessage = '';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const maxIndex = this._items.length - 1;
+    if (this.currentIndex > maxIndex) {
+      this.currentIndex = maxIndex;
+    }
+    if (this.currentIndex < 0) {
+      this.currentIndex = 0;
+    }
+
+    if (this.isDisabled(this.currentIndex)) {
+      const fallback = this.findNextEnabled(this.currentIndex, 1) ?? this.findNextEnabled(this.currentIndex, -1);
+      this.currentIndex = fallback ?? this.currentIndex;
+    }
+
+    if (this.isDisabled(this.focusedIndex) || this.focusedIndex >= this._items.length) {
+      this.focusedIndex = this.currentIndex;
+    }
+
+    this.ensureFocusVisibility();
+    this.updateLiveMessage();
+  }
+
+  private ensureFocusVisibility(): void {
+    if (!this._items.length || !this.itemComponents) {
+      return;
+    }
+
+    if (this.isDisabled(this.focusedIndex)) {
+      const enabled = this.findNextEnabled(this.focusedIndex, 1) ?? this.findNextEnabled(this.focusedIndex, -1);
+      if (enabled != null) {
+        this.focusedIndex = enabled;
+      }
+    }
+
+    this.cdr.markForCheck();
+  }
+
+  private moveFocus(direction: 1 | -1): boolean {
+    const next = this.findNextEnabled(this.focusedIndex, direction);
+    if (next == null) {
+      return false;
+    }
+    this.focusItem(next);
+    return true;
+  }
+
+  private focusEdge(toStart: boolean): boolean {
+    const index = toStart ? this.findEdgeEnabled(0, 1) : this.findEdgeEnabled(this._items.length - 1, -1);
+    if (index == null) {
+      return false;
+    }
+    this.focusItem(index);
+    return true;
+  }
+
+  private focusItem(index: number): void {
+    if (index < 0 || index >= this._items.length) {
+      return;
+    }
+    this.focusedIndex = index;
+    const component = this.itemComponents?.get(index);
+    component?.focus();
+    this.stepFocus.emit(index);
+    this.cdr.markForCheck();
+  }
+
+  private findNextEnabled(start: number, direction: 1 | -1): number | null {
+    let index = start + direction;
+    while (index >= 0 && index < this._items.length) {
+      if (!this.isDisabled(index)) {
+        return index;
+      }
+      index += direction;
+    }
+    return null;
+  }
+
+  private findEdgeEnabled(start: number, direction: 1 | -1): number | null {
+    let index = start;
+    while (index >= 0 && index < this._items.length) {
+      if (!this.isDisabled(index)) {
+        return index;
+      }
+      index += direction;
+    }
+    return null;
+  }
+
+  private updateLiveMessage(): void {
+    if (!this._items.length || this.currentIndex < 0 || this.currentIndex >= this._items.length) {
+      this.liveMessage = '';
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const current = this._items[this.currentIndex];
+    const total = this._items.length;
+    const indexText = this.currentIndex + 1;
+    const optionalText = current.optionalLabel ? ` (${current.optionalLabel})` : '';
+    const statusText = current.state === 'current' ? ' (atual)' : '';
+    this.liveMessage = `Etapa ${indexText} de ${total}: ${current.label}${optionalText}${statusText}`;
+    this.cdr.markForCheck();
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone `app-progress-indicator` container mirroring Carbon styles with orientation, skeleton and keyboard support
- create reusable `app-progress-indicator-item` with tooltip, state visuals and accessibility hooks
- cover keyboard navigation with a focused unit test

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e64e1e808331bfa95e8ce44dc6a4