### PR TITLE
feat: add Angular standalone UserProfile component

### DIFF
--- a/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.html
+++ b/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.html
@@ -1,0 +1,372 @@
+<section
+  class="user-profile"
+  [ngClass]="['size-' + size, fluid ? 'is-fluid' : '', readonly ? 'is-readonly' : '', (skeleton || loading) ? 'is-skeleton' : '']"
+  role="form"
+  [attr.aria-label]="'Perfil do usuário'"
+>
+  <header class="user-profile__header" role="group" [attr.aria-describedby]="idPrefix + '-subtitle'">
+    <nav class="user-profile__breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="#" tabindex="-1">Início</a></li>
+        <li><a href="#" tabindex="-1">Configurações</a></li>
+        <li aria-current="page">Meu perfil</li>
+      </ol>
+    </nav>
+    <h1 #titleRef tabindex="-1" class="user-profile__title">Meu perfil</h1>
+    <p id="{{ idPrefix }}-subtitle" class="user-profile__subtitle">Gerencie seus dados pessoais e preferências</p>
+    <p class="user-profile__updated" *ngIf="lastUpdatedLabel">
+      <i class="fa-regular fa-clock" aria-hidden="true"></i>
+      Última atualização em: {{ lastUpdatedLabel }}
+    </p>
+  </header>
+
+  <div *ngIf="errorMsg" class="user-profile__feedback user-profile__feedback--error" role="alert" aria-live="assertive">
+    <i class="fa-solid fa-circle-exclamation" aria-hidden="true"></i>
+    <span>{{ errorMsg }}</span>
+  </div>
+
+  <div *ngIf="successMsg" class="user-profile__feedback user-profile__feedback--success" role="status" aria-live="polite">
+    <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+    <span>{{ successMsg }}</span>
+  </div>
+
+  <div *ngIf="passwordMsg" class="user-profile__feedback user-profile__feedback--info" role="status" aria-live="polite">
+    <i class="fa-solid fa-lock" aria-hidden="true"></i>
+    <span>{{ passwordMsg }}</span>
+  </div>
+
+  <ng-container *ngIf="skeleton || loading; else profileContent">
+    <div class="user-profile__skeleton" aria-hidden="true">
+      <div class="user-profile__grid">
+        <div class="user-profile__column user-profile__column--left">
+          <div class="card card--summary">
+            <div class="skeleton avatar"></div>
+            <div class="skeleton skeleton-text w-60"></div>
+            <div class="skeleton skeleton-text w-80"></div>
+            <div class="skeleton skeleton-text w-40"></div>
+            <div class="skeleton skeleton-button"></div>
+          </div>
+        </div>
+        <div class="user-profile__column user-profile__column--right">
+          <div class="card card--form">
+            <div class="skeleton skeleton-text w-50"></div>
+            <div class="skeleton skeleton-input"></div>
+            <div class="skeleton skeleton-input"></div>
+            <div class="skeleton skeleton-input"></div>
+          </div>
+          <div class="card card--form">
+            <div class="skeleton skeleton-text w-40"></div>
+            <div class="skeleton skeleton-input"></div>
+          </div>
+          <div class="card card--form">
+            <div class="skeleton skeleton-text w-50"></div>
+            <div class="skeleton skeleton-input"></div>
+            <div class="skeleton skeleton-input"></div>
+            <div class="skeleton skeleton-input"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
+  <ng-template #profileContent>
+    <div class="user-profile__grid">
+      <div class="user-profile__column user-profile__column--left">
+        <article class="card card--summary" role="group" [attr.aria-labelledby]="idPrefix + '-summary-title'">
+          <h2 id="{{ idPrefix }}-summary-title" class="card__title">Resumo</h2>
+          <figure class="avatar" role="img" [attr.aria-label]="profileForm.get('name')?.value || 'Avatar do usuário'">
+            <img *ngIf="avatarUrl; else avatarFallback" [src]="avatarUrl" [alt]="profileForm.get('name')?.value || 'Avatar do usuário'" />
+            <ng-template #avatarFallback>
+              <div class="avatar__fallback" aria-hidden="true">
+                <i class="fa-solid fa-user"></i>
+              </div>
+            </ng-template>
+          </figure>
+
+          <div class="avatar__actions">
+            <input
+              #fileInput
+              type="file"
+              class="visually-hidden"
+              accept="image/png,image/jpeg"
+              (change)="onChangeAvatar($event)"
+              [disabled]="readonly"
+            />
+            <button
+              #changePhotoBtn
+              type="button"
+              class="btn btn--secondary"
+              (click)="openAvatarDialog()"
+              [disabled]="readonly || avatarLoading"
+              [attr.aria-busy]="avatarLoading"
+            >
+              <span *ngIf="avatarLoading" class="spinner" aria-live="polite"></span>
+              <i class="fa-solid fa-camera" aria-hidden="true"></i>
+              Alterar foto
+            </button>
+            <button type="button" class="btn btn--ghost" (click)="removeAvatar()" [disabled]="readonly || !avatarUrl || avatarLoading">
+              <i class="fa-solid fa-trash" aria-hidden="true"></i>
+              Remover
+            </button>
+          </div>
+
+          <dl class="summary-list">
+            <div>
+              <dt>Nome</dt>
+              <dd>{{ snapshot?.name || '-' }}</dd>
+            </div>
+            <div>
+              <dt>E-mail</dt>
+              <dd>{{ snapshot?.email || '-' }}</dd>
+            </div>
+            <div>
+              <dt>Papel</dt>
+              <dd>{{ snapshot?.role || '-' }}</dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+
+      <div class="user-profile__column user-profile__column--right">
+        <form
+          class="card card--form"
+          role="group"
+          [attr.aria-labelledby]="idPrefix + '-profile-title'"
+          [formGroup]="profileForm"
+          novalidate
+        >
+          <h2 id="{{ idPrefix }}-profile-title" class="card__title">Dados pessoais</h2>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-name'">Nome completo *</label>
+            <input
+              [id]="idPrefix + '-name'"
+              type="text"
+              formControlName="name"
+              [attr.aria-invalid]="profileForm.get('name')?.invalid && profileForm.get('name')?.touched"
+              [attr.aria-describedby]="idPrefix + '-name-msg'"
+              [readonly]="readonly"
+            />
+            <span
+              *ngIf="profileForm.get('name')?.invalid && profileForm.get('name')?.touched"
+              [id]="idPrefix + '-name-msg'"
+              class="field-msg field-msg--error"
+              aria-live="assertive"
+            >
+              O nome deve conter ao menos 3 caracteres.
+            </span>
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-email'">E-mail</label>
+            <input [id]="idPrefix + '-email'" type="email" formControlName="email" readonly />
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-phone'">Telefone</label>
+            <input
+              [id]="idPrefix + '-phone'"
+              type="text"
+              formControlName="phone"
+              placeholder="Ex.: +55 11 90000-0000"
+              [attr.aria-invalid]="profileForm.get('phone')?.invalid && profileForm.get('phone')?.touched"
+              [attr.aria-describedby]="idPrefix + '-phone-msg'"
+              [readonly]="readonly"
+            />
+            <span
+              *ngIf="profileForm.get('phone')?.invalid && profileForm.get('phone')?.touched"
+              [id]="idPrefix + '-phone-msg'"
+              class="field-msg field-msg--error"
+              aria-live="assertive"
+            >
+              Informe um telefone válido.
+            </span>
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-unit'">Comarca/Unidade</label>
+            <input [id]="idPrefix + '-unit'" type="text" formControlName="unit" [readonly]="readonly" />
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-availability'">Disponibilidade</label>
+            <textarea
+              [id]="idPrefix + '-availability'"
+              formControlName="availability"
+              rows="3"
+              [readonly]="readonly"
+            ></textarea>
+          </div>
+        </form>
+
+        <form
+          class="card card--form"
+          role="group"
+          [attr.aria-labelledby]="idPrefix + '-prefs-title'"
+          [formGroup]="preferencesForm"
+          novalidate
+        >
+          <h2 id="{{ idPrefix }}-prefs-title" class="card__title">Preferências</h2>
+
+          <fieldset class="field" role="group" [attr.aria-labelledby]="idPrefix + '-theme-label'">
+            <legend id="{{ idPrefix }}-theme-label" class="field-label">Tema</legend>
+            <div class="radio-group">
+              <label [attr.for]="idPrefix + '-theme-light'" class="radio">
+                <input
+                  type="radio"
+                  [id]="idPrefix + '-theme-light'"
+                  value="light"
+                  formControlName="theme"
+                  [disabled]="readonly"
+                />
+                Claro
+              </label>
+              <label [attr.for]="idPrefix + '-theme-dark'" class="radio">
+                <input
+                  type="radio"
+                  [id]="idPrefix + '-theme-dark'"
+                  value="dark"
+                  formControlName="theme"
+                  [disabled]="readonly"
+                />
+                Escuro
+              </label>
+              <label [attr.for]="idPrefix + '-theme-system'" class="radio">
+                <input
+                  type="radio"
+                  [id]="idPrefix + '-theme-system'"
+                  value="system"
+                  formControlName="theme"
+                  [disabled]="readonly"
+                />
+                Sistema
+              </label>
+            </div>
+          </fieldset>
+
+          <div class="field checkbox-field">
+            <label class="checkbox" [attr.for]="idPrefix + '-email-notify'">
+              <input
+                type="checkbox"
+                [id]="idPrefix + '-email-notify'"
+                formControlName="emailNotifications"
+                [disabled]="readonly"
+              />
+              Receber notificações por e-mail
+            </label>
+          </div>
+        </form>
+
+        <form
+          class="card card--form"
+          role="group"
+          [attr.aria-labelledby]="idPrefix + '-password-title'"
+          [formGroup]="passwordForm"
+          novalidate
+        >
+          <h2 id="{{ idPrefix }}-password-title" class="card__title">Alterar senha</h2>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-current-password'">Senha atual *</label>
+            <input
+              [id]="idPrefix + '-current-password'"
+              type="password"
+              formControlName="currentPassword"
+              autocomplete="current-password"
+              [attr.aria-invalid]="passwordForm.get('currentPassword')?.invalid && passwordForm.get('currentPassword')?.touched"
+              [attr.aria-describedby]="idPrefix + '-current-password-msg'"
+              [readonly]="readonly"
+            />
+            <span
+              *ngIf="passwordForm.get('currentPassword')?.invalid && passwordForm.get('currentPassword')?.touched"
+              [id]="idPrefix + '-current-password-msg'"
+              class="field-msg field-msg--error"
+              aria-live="assertive"
+            >
+              Informe sua senha atual.
+            </span>
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-new-password'">Nova senha *</label>
+            <input
+              [id]="idPrefix + '-new-password'"
+              type="password"
+              formControlName="newPassword"
+              autocomplete="new-password"
+              [attr.aria-invalid]="passwordForm.get('newPassword')?.invalid && passwordForm.get('newPassword')?.touched"
+              [attr.aria-describedby]="idPrefix + '-new-password-msg'"
+              [readonly]="readonly"
+            />
+            <span class="password-strength" aria-live="polite">
+              Força: {{ passwordStrength }}
+            </span>
+            <span
+              *ngIf="passwordForm.get('newPassword')?.invalid && passwordForm.get('newPassword')?.touched"
+              [id]="idPrefix + '-new-password-msg'"
+              class="field-msg field-msg--error"
+              aria-live="assertive"
+            >
+              A senha deve ter ao menos 8 caracteres, uma letra maiúscula e um número.
+            </span>
+          </div>
+
+          <div class="field">
+            <label class="field-label" [attr.for]="idPrefix + '-confirm-password'">Confirmar senha *</label>
+            <input
+              [id]="idPrefix + '-confirm-password'"
+              type="password"
+              formControlName="confirmPassword"
+              autocomplete="new-password"
+              [attr.aria-invalid]="passwordForm.get('confirmPassword')?.invalid && passwordForm.get('confirmPassword')?.touched"
+              [attr.aria-describedby]="idPrefix + '-confirm-password-msg'"
+              [readonly]="readonly"
+            />
+            <span
+              *ngIf="passwordForm.get('confirmPassword')?.invalid && passwordForm.get('confirmPassword')?.touched"
+              [id]="idPrefix + '-confirm-password-msg'"
+              class="field-msg field-msg--error"
+              aria-live="assertive"
+            >
+              {{
+                passwordForm.get('confirmPassword')?.hasError('required')
+                  ? 'Confirme a nova senha.'
+                  : 'As senhas não conferem.'
+              }}
+            </span>
+          </div>
+
+          <div class="card__actions">
+            <button
+              type="button"
+              class="btn btn--primary"
+              (click)="onChangePassword()"
+              [disabled]="readonly || passwordSaving || passwordForm.invalid"
+              [attr.aria-busy]="passwordSaving"
+            >
+              <span *ngIf="passwordSaving" class="spinner" aria-live="polite"></span>
+              Atualizar senha
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </ng-template>
+
+  <footer class="user-profile__footer">
+    <button
+      type="button"
+      class="btn btn--primary"
+      (click)="onSave()"
+      [disabled]="readonly || saving || profileForm.invalid || preferencesForm.invalid"
+      [attr.aria-busy]="saving"
+    >
+      <span *ngIf="saving" class="spinner" aria-live="polite"></span>
+      Salvar
+    </button>
+    <button type="button" class="btn btn--ghost" (click)="onCancel()">Cancelar</button>
+    <button type="button" class="btn btn--secondary" (click)="onRevert()" [disabled]="readonly">
+      Reverter alterações
+    </button>
+  </footer>
+</section>

--- a/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.scss
+++ b/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.scss
@@ -1,0 +1,525 @@
+@import "../../general/colors/colors.scss";
+
+$user-profile-radius: 0.75rem;
+
+.user-profile {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background-color: $neutral-100;
+  color: $neutral-800;
+
+  &.is-fluid {
+    width: 100%;
+  }
+
+  &.is-readonly {
+    .card {
+      opacity: 0.85;
+    }
+
+    input,
+    textarea,
+    button,
+    label,
+    fieldset {
+      cursor: not-allowed;
+    }
+  }
+
+  &.is-skeleton {
+    .card {
+      pointer-events: none;
+    }
+  }
+}
+
+.user-profile__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .user-profile__title {
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1.2;
+    color: $neutral-900;
+  }
+
+  .user-profile__subtitle {
+    font-size: 1rem;
+    color: $neutral-600;
+  }
+
+  .user-profile__updated {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.875rem;
+    color: $neutral-500;
+  }
+}
+
+.user-profile__breadcrumb {
+  font-size: 0.875rem;
+  color: $neutral-500;
+
+  ol {
+    display: flex;
+    gap: 0.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    &::after {
+      content: "/";
+      color: $neutral-400;
+    }
+
+    &:last-child::after {
+      content: "";
+    }
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+.user-profile__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.user-profile__column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: $neutral-50;
+  border: 1px solid $neutral-200;
+  border-radius: $user-profile-radius;
+  padding: 1.5rem;
+  box-shadow: 0 4px 16px rgba($neutral-900, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  &__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: $neutral-900;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+}
+
+.card--summary {
+  align-items: center;
+  text-align: center;
+}
+
+.avatar {
+  width: 8rem;
+  height: 8rem;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 4px solid $neutral-100;
+  background-color: $neutral-100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+  }
+
+  &__fallback {
+    font-size: 3rem;
+    color: $neutral-400;
+  }
+
+  &__actions {
+    margin-top: 0.75rem;
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+.summary-list {
+  width: 100%;
+  display: grid;
+  gap: 0.75rem;
+
+  div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  dt {
+    font-weight: 600;
+    color: $neutral-600;
+  }
+
+  dd {
+    margin: 0;
+    color: $neutral-800;
+    font-weight: 500;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.field-label {
+  font-size: 0.875rem;
+  color: $neutral-700;
+  font-weight: 600;
+}
+
+.field input,
+.field textarea {
+  border: 1px solid $neutral-300;
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+  background-color: $neutral-50;
+  color: $neutral-800;
+
+  &:focus {
+    outline: none;
+    border-color: $blue-500;
+    box-shadow: 0 0 0 3px rgba($blue-500, 0.2);
+  }
+
+  &:disabled,
+  &[readonly] {
+    background-color: $neutral-100;
+    color: $neutral-500;
+  }
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.field-msg {
+  font-size: 0.75rem;
+  line-height: 1.2;
+
+  &--error {
+    color: $red-800;
+  }
+}
+
+.password-strength {
+  font-size: 0.75rem;
+  color: $neutral-600;
+}
+
+.radio-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.radio,
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: $neutral-700;
+
+  input {
+    accent-color: $blue-600;
+  }
+}
+
+.checkbox-field {
+  margin-top: 0.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid rgba($neutral-50, 0);
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid $blue-500;
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.btn--primary {
+  background-color: $blue-600;
+  color: $neutral-50;
+  border-color: $blue-600;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background-color: $blue-700;
+    border-color: $blue-700;
+  }
+
+  &:active:not(:disabled) {
+    background-color: $blue-800;
+    border-color: $blue-800;
+  }
+}
+
+.btn--secondary {
+  background-color: $neutral-50;
+  color: $blue-600;
+  border-color: $blue-600;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background-color: $blue-50;
+  }
+
+  &:active:not(:disabled) {
+    background-color: $blue-100;
+  }
+}
+
+.btn--ghost {
+  background-color: rgba($neutral-50, 0);
+  color: $neutral-700;
+  border-color: $neutral-200;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background-color: $neutral-100;
+  }
+
+  &:active:not(:disabled) {
+    background-color: $neutral-200;
+  }
+}
+
+.spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid rgba($neutral-50, 0);
+  border-top-color: $neutral-400;
+  border-right-color: $neutral-400;
+  animation: spin 0.6s linear infinite;
+}
+
+.user-profile__feedback {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+
+  &--error {
+    background-color: $red-50;
+    color: $red-800;
+    border: 1px solid $red-200;
+  }
+
+  &--success {
+    background-color: $green-50;
+    color: $green-700;
+    border: 1px solid $green-200;
+  }
+
+  &--info {
+    background-color: $blue-alt-50;
+    color: $blue-700;
+    border: 1px solid $blue-alt-200;
+  }
+}
+
+.user-profile__footer {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  border-top: 1px solid $neutral-200;
+}
+
+.user-profile__skeleton {
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    background-color: $neutral-100;
+    border-radius: 0.5rem;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, rgba($neutral-50, 0), rgba($neutral-50, 0.6), rgba($neutral-50, 0));
+      animation: shimmer 1.2s infinite;
+    }
+  }
+
+  .skeleton-text {
+    height: 1rem;
+  }
+
+  .skeleton-input {
+    height: 2.75rem;
+  }
+
+  .skeleton-button {
+    height: 2.5rem;
+  }
+
+  .w-40 {
+    width: 40%;
+  }
+
+  .w-50 {
+    width: 50%;
+  }
+
+  .w-60 {
+    width: 60%;
+  }
+
+  .w-80 {
+    width: 80%;
+  }
+}
+
+.size-sm {
+  padding: 1.5rem;
+
+  .card {
+    padding: 1.25rem;
+  }
+
+  .btn {
+    padding: 0.5rem 1.25rem;
+    font-size: 0.9rem;
+  }
+}
+
+.size-md {
+  padding: 2rem;
+}
+
+.size-lg {
+  padding: 2.5rem;
+
+  .card {
+    padding: 2rem;
+  }
+
+  .btn {
+    padding: 0.75rem 1.75rem;
+    font-size: 1rem;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 991px) {
+  .user-profile__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .user-profile__column--left {
+    order: 1;
+  }
+
+  .user-profile__column--right {
+    order: 2;
+  }
+}
+
+@media (max-width: 479px) {
+  .user-profile {
+    padding: 1.25rem;
+  }
+
+  .avatar {
+    width: 6rem;
+    height: 6rem;
+  }
+
+  .user-profile__footer {
+    flex-direction: column;
+    align-items: stretch;
+
+    .btn {
+      width: 100%;
+    }
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.component.ts
@@ -1,0 +1,521 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, ElementRef, EventEmitter, HostListener, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { BehaviorSubject, EMPTY, Observable, Subject, of, throwError } from 'rxjs';
+import { catchError, delay, finalize, takeUntil, tap } from 'rxjs/operators';
+
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  role: 'Administrador' | 'Agente' | 'Outro';
+  phone?: string;
+  unit?: string;
+  availability?: string;
+  avatarUrl?: string;
+  updatedAt?: string;
+  preferences?: {
+    theme: 'light' | 'dark' | 'system';
+    emailNotifications: boolean;
+  };
+}
+
+interface PasswordPayload {
+  currentPassword: string;
+  newPassword: string;
+}
+
+@Injectable()
+export class UserProfileService {
+  private readonly latency = 800;
+  private readonly profile$ = new BehaviorSubject<UserProfile>({
+    id: 'usr-001',
+    name: 'Ana Paula Oliveira',
+    email: 'ana.oliveira@example.com',
+    role: 'Agente',
+    phone: '+55 11 98888-1234',
+    unit: 'Comarca de São Paulo',
+    availability: 'Seg a Sex - 09h às 17h',
+    avatarUrl: 'https://i.pravatar.cc/160?img=47',
+    updatedAt: new Date().toISOString(),
+    preferences: {
+      theme: 'system',
+      emailNotifications: true,
+    },
+  });
+
+  getProfile(): Observable<UserProfile> {
+    return this.profile$.pipe(delay(this.latency));
+  }
+
+  updateProfile(payload: Partial<UserProfile>): Observable<UserProfile> {
+    const updated: UserProfile = {
+      ...this.profile$.value,
+      ...payload,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.profile$.next(updated);
+    return of(updated).pipe(delay(this.latency));
+    // TODO: integrar com endpoint real, ex.: PATCH /api/me
+  }
+
+  updateAvatar(file: File): Observable<string> {
+    const currentAvatar = this.profile$.value.avatarUrl;
+    if (currentAvatar?.startsWith('blob:')) {
+      URL.revokeObjectURL(currentAvatar);
+    }
+    const fakeUrl = URL.createObjectURL(file);
+    const updated = {
+      ...this.profile$.value,
+      avatarUrl: fakeUrl,
+      updatedAt: new Date().toISOString(),
+    };
+    this.profile$.next(updated);
+    return of(fakeUrl).pipe(delay(this.latency));
+    // TODO: integrar com endpoint real, ex.: POST /api/me/avatar
+  }
+
+  changePassword(payload: PasswordPayload): Observable<void> {
+    if (payload.currentPassword === 'erro') {
+      return throwError(() => new Error('Senha atual incorreta.')); // Simulação de erro
+    }
+
+    return of(void 0).pipe(delay(this.latency));
+    // TODO: integrar com endpoint real, ex.: POST /api/me/password
+  }
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-user-profile',
+  imports: [CommonModule, NgClass, ReactiveFormsModule],
+  templateUrl: './user-profile.component.html',
+  styleUrl: './user-profile.component.scss',
+  providers: [UserProfileService]
+})
+export class UserProfileComponent implements OnInit, OnDestroy, OnChanges {
+  @Input() readonly = false;
+  @Input() skeleton = false;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() fluid = false;
+
+  @Output() saved = new EventEmitter<UserProfile>();
+  @Output() avatarChanged = new EventEmitter<string>();
+  @Output() passwordChanged = new EventEmitter<void>();
+  @Output() canceled = new EventEmitter<void>();
+
+  @ViewChild('titleRef', { static: false }) titleRef?: ElementRef<HTMLHeadingElement>;
+  @ViewChild('fileInput', { static: false }) fileInput?: ElementRef<HTMLInputElement>;
+  @ViewChild('changePhotoBtn', { static: false }) changePhotoBtn?: ElementRef<HTMLButtonElement>;
+
+  readonly idPrefix = `user-profile-${Math.random().toString(36).substring(2, 9)}`;
+  profileForm: FormGroup;
+  preferencesForm: FormGroup;
+  passwordForm: FormGroup;
+
+  loading = false;
+  saving = false;
+  passwordSaving = false;
+  avatarLoading = false;
+  errorMsg = '';
+  successMsg = '';
+  passwordMsg = '';
+  avatarPreview?: string | null;
+  private destroy$ = new Subject<void>();
+  private snapshot?: UserProfile;
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly service: UserProfileService,
+    private readonly hostRef: ElementRef<HTMLElement>
+  ) {
+    this.profileForm = this.fb.group({
+      name: ['', [Validators.required, Validators.minLength(3)]],
+      email: [{ value: '', disabled: true }],
+      phone: ['', [Validators.pattern(/^\+?[0-9\s()-]{8,20}$/)]],
+      unit: [''],
+      availability: [''],
+    });
+
+    this.preferencesForm = this.fb.group({
+      theme: ['system', Validators.required],
+      emailNotifications: [false],
+    });
+
+    this.passwordForm = this.fb.group({
+      currentPassword: ['', Validators.required],
+      newPassword: ['', [Validators.required, Validators.minLength(8), this.uppercaseValidator, this.numberValidator]],
+      confirmPassword: ['', Validators.required],
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  ngOnInit(): void {
+    if (!this.skeleton) {
+      this.loadProfile();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['skeleton'] && !changes['skeleton'].currentValue && !this.snapshot) {
+      this.loadProfile();
+    }
+
+    if (changes['readonly']) {
+      this.applyReadonlyState();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.avatarPreview?.startsWith('blob:')) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  handleKeydown(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (target && !this.hostRef.nativeElement.contains(target)) {
+      return;
+    }
+
+    const isSave = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's';
+    if (isSave) {
+      event.preventDefault();
+      this.onSave();
+      return;
+    }
+
+    if (event.key === 'Enter' && !event.shiftKey) {
+      const tagName = target?.tagName?.toLowerCase();
+      if (tagName && tagName !== 'textarea' && tagName !== 'button' && tagName !== 'a') {
+        event.preventDefault();
+        this.onSave();
+        return;
+      }
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.onCancel();
+    }
+  }
+
+  onSave(): void {
+    if (this.readonly || this.profileForm.invalid || this.preferencesForm.invalid) {
+      this.profileForm.markAllAsTouched();
+      this.preferencesForm.markAllAsTouched();
+      return;
+    }
+
+    this.saving = true;
+    this.errorMsg = '';
+    this.successMsg = '';
+
+    const payload: Partial<UserProfile> = {
+      ...this.profileForm.getRawValue(),
+      preferences: this.preferencesForm.value,
+      avatarUrl: this.avatarPreview || undefined,
+    };
+
+    if (typeof payload.name === 'string') {
+      payload.name = payload.name.trim();
+      this.profileForm.get('name')?.setValue(payload.name, { emitEvent: false });
+    }
+
+    this.service.updateProfile(payload).pipe(
+      takeUntil(this.destroy$),
+      tap(profile => {
+        this.snapshot = profile;
+        this.avatarPreview = profile.avatarUrl ?? this.avatarPreview;
+        this.successMsg = 'Perfil atualizado com sucesso.';
+        this.saved.emit(profile);
+      }),
+      catchError((error: Error) => {
+        this.errorMsg = error.message || 'Não foi possível atualizar o perfil.';
+        return of(this.snapshot as UserProfile);
+      }),
+      finalize(() => {
+        this.saving = false;
+        setTimeout(() => this.focusTitle(), 0);
+      })
+    ).subscribe();
+  }
+
+  onChangeAvatar(event: Event): void {
+    if (this.readonly) {
+      return;
+    }
+
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      this.restoreFocusToAvatarButton();
+      return;
+    }
+
+    const isValidType = ['image/png', 'image/jpeg', 'image/jpg'].includes(file.type);
+    if (!isValidType) {
+      this.errorMsg = 'Formato de imagem não suportado.';
+      this.clearFileInput();
+      this.restoreFocusToAvatarButton();
+      return;
+    }
+
+    const currentPreview = this.avatarPreview;
+    if (currentPreview?.startsWith('blob:')) {
+      URL.revokeObjectURL(currentPreview);
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    this.avatarPreview = previewUrl;
+    this.avatarLoading = true;
+    this.service.updateAvatar(file).pipe(
+      takeUntil(this.destroy$),
+      tap(url => {
+        this.avatarPreview = url;
+        this.successMsg = 'Avatar atualizado com sucesso.';
+        this.errorMsg = '';
+        this.avatarChanged.emit(url);
+      }),
+      catchError((error: Error) => {
+        this.errorMsg = error.message || 'Erro ao atualizar avatar.';
+        this.avatarPreview = currentPreview || this.snapshot?.avatarUrl;
+        return of('');
+      }),
+      finalize(() => {
+        this.avatarLoading = false;
+        if (previewUrl && previewUrl !== this.avatarPreview && previewUrl.startsWith('blob:')) {
+          URL.revokeObjectURL(previewUrl);
+        }
+        this.clearFileInput();
+        this.restoreFocusToAvatarButton();
+      })
+    ).subscribe();
+  }
+
+  openAvatarDialog(): void {
+    if (this.readonly) {
+      return;
+    }
+    this.fileInput?.nativeElement.click();
+  }
+
+  removeAvatar(): void {
+    if (this.readonly) {
+      return;
+    }
+
+    if (this.avatarPreview?.startsWith('blob:')) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+    this.avatarPreview = undefined;
+    this.successMsg = 'Avatar removido. Salve para aplicar permanentemente.';
+    this.errorMsg = '';
+  }
+
+  onChangePassword(): void {
+    if (this.readonly || this.passwordForm.invalid) {
+      this.passwordForm.markAllAsTouched();
+      return;
+    }
+
+    this.passwordSaving = true;
+    this.passwordMsg = '';
+    this.errorMsg = '';
+
+    const payload: PasswordPayload = {
+      currentPassword: this.passwordForm.value.currentPassword,
+      newPassword: this.passwordForm.value.newPassword,
+    };
+
+    this.service.changePassword(payload).pipe(
+      takeUntil(this.destroy$),
+      tap(() => {
+        this.passwordMsg = 'Senha alterada com sucesso.';
+        this.passwordChanged.emit();
+        this.passwordForm.reset();
+      }),
+      catchError((error: Error) => {
+        this.errorMsg = error.message || 'Erro ao alterar senha.';
+        return of(void 0);
+      }),
+      finalize(() => {
+        this.passwordSaving = false;
+      })
+    ).subscribe();
+  }
+
+  onCancel(): void {
+    if (this.readonly) {
+      this.canceled.emit();
+      return;
+    }
+
+    this.restoreSnapshot();
+    this.canceled.emit();
+  }
+
+  onRevert(): void {
+    if (this.readonly) {
+      return;
+    }
+
+    this.restoreSnapshot();
+  }
+
+  get passwordStrength(): 'fraca' | 'media' | 'forte' {
+    const value: string = this.passwordForm.value.newPassword || '';
+    if (!value) {
+      return 'fraca';
+    }
+
+    const strong = value.length >= 12 && /[A-Z]/.test(value) && /[0-9]/.test(value) && /[^A-Za-z0-9]/.test(value);
+    const medium = value.length >= 9 && /[A-Z]/.test(value) && /[0-9]/.test(value);
+
+    if (strong) {
+      return 'forte';
+    }
+
+    if (medium) {
+      return 'media';
+    }
+
+    return 'fraca';
+  }
+
+  get lastUpdatedLabel(): string {
+    if (!this.snapshot?.updatedAt) {
+      return '';
+    }
+
+    const date = new Date(this.snapshot.updatedAt);
+    return new Intl.DateTimeFormat('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  }
+
+  get avatarUrl(): string | undefined {
+    return this.avatarPreview || this.snapshot?.avatarUrl || undefined;
+  }
+
+  focusTitle(): void {
+    setTimeout(() => {
+      this.titleRef?.nativeElement?.focus();
+    });
+  }
+
+  private loadProfile(): void {
+    this.loading = true;
+    this.errorMsg = '';
+    this.successMsg = '';
+    this.service.getProfile().pipe(
+      takeUntil(this.destroy$),
+      tap(profile => {
+        this.snapshot = profile;
+        this.avatarPreview = profile.avatarUrl;
+        this.profileForm.patchValue({
+          name: profile.name,
+          email: profile.email,
+          phone: profile.phone ?? '',
+          unit: profile.unit ?? '',
+          availability: profile.availability ?? '',
+        });
+        this.preferencesForm.patchValue(profile.preferences ?? {
+          theme: 'system',
+          emailNotifications: true,
+        });
+        this.profileForm.markAsPristine();
+        this.preferencesForm.markAsPristine();
+        this.applyReadonlyState();
+        this.focusTitle();
+      }),
+      catchError((error: Error) => {
+        this.errorMsg = error.message || 'Não foi possível carregar o perfil.';
+        this.successMsg = '';
+        return EMPTY;
+      }),
+      finalize(() => {
+        this.loading = false;
+      })
+    ).subscribe();
+  }
+
+  private restoreSnapshot(): void {
+    if (!this.snapshot) {
+      return;
+    }
+
+    this.profileForm.reset({
+      name: this.snapshot.name,
+      email: this.snapshot.email,
+      phone: this.snapshot.phone ?? '',
+      unit: this.snapshot.unit ?? '',
+      availability: this.snapshot.availability ?? '',
+    });
+
+    this.preferencesForm.reset(this.snapshot.preferences ?? {
+      theme: 'system',
+      emailNotifications: true,
+    });
+
+    this.passwordForm.reset();
+    this.avatarPreview = this.snapshot.avatarUrl;
+    this.successMsg = '';
+    this.errorMsg = '';
+    this.passwordMsg = '';
+    this.applyReadonlyState();
+  }
+
+  private applyReadonlyState(): void {
+    const shouldDisable = this.readonly;
+    const controls = [this.profileForm, this.preferencesForm, this.passwordForm];
+    controls.forEach(form => {
+      if (shouldDisable) {
+        form.disable({ emitEvent: false });
+      } else {
+        form.enable({ emitEvent: false });
+      }
+    });
+
+    this.profileForm.get('email')?.disable({ emitEvent: false });
+  }
+
+  private clearFileInput(): void {
+    if (this.fileInput?.nativeElement) {
+      this.fileInput.nativeElement.value = '';
+    }
+  }
+
+  private restoreFocusToAvatarButton(): void {
+    setTimeout(() => this.changePhotoBtn?.nativeElement.focus(), 0);
+  }
+
+  private uppercaseValidator(control: import('@angular/forms').AbstractControl) {
+    const value = control.value as string;
+    if (!value) {
+      return null;
+    }
+    return /[A-Z]/.test(value) ? null : { uppercase: true };
+  }
+
+  private numberValidator(control: import('@angular/forms').AbstractControl) {
+    const value = control.value as string;
+    if (!value) {
+      return null;
+    }
+    return /[0-9]/.test(value) ? null : { number: true };
+  }
+
+  private passwordMatchValidator(group: FormGroup) {
+    const newPassword = group.get('newPassword')?.value;
+    const confirmPassword = group.get('confirmPassword')?.value;
+    return newPassword && confirmPassword && newPassword !== confirmPassword ? { mismatch: true } : null;
+  }
+}

--- a/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.mocks.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.mocks.ts
@@ -1,0 +1,19 @@
+import { UserProfile } from './user-profile.component';
+
+export const userProfileMock: UserProfile = {
+  id: 'usr-001',
+  name: 'Ana Paula Oliveira',
+  email: 'ana.oliveira@example.com',
+  role: 'Agente',
+  phone: '+55 11 98888-1234',
+  unit: 'Comarca de São Paulo',
+  availability: 'Segunda a Sexta, das 09h às 17h',
+  avatarUrl: 'https://i.pravatar.cc/160?img=47',
+  updatedAt: new Date().toISOString(),
+  preferences: {
+    theme: 'system',
+    emailNotifications: true,
+  },
+};
+
+export const userProfileErrorMock = new Error('Simulação de erro ao carregar o perfil.');

--- a/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.stories.ts
+++ b/frontend/agentes-frontend/src/app/shared/components/user-profile/user-profile.stories.ts
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { applicationConfig, moduleMetadata } from '@storybook/angular';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { action } from '@storybook/addon-actions';
+import { throwError } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+import { UserProfileComponent, UserProfileService } from './user-profile.component';
+class ErrorUserProfileService extends UserProfileService {
+  override getProfile() {
+    return throwError(() => new Error('Não foi possível carregar o perfil (mock).')).pipe(delay(300));
+  }
+}
+
+const meta: Meta<UserProfileComponent> = {
+  title: 'Shared/Components/UserProfile',
+  component: UserProfileComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideAnimations()],
+    }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'Componente de perfil do usuário com formulário, preferências, avatar e alteração de senha.',
+      },
+    },
+  },
+  args: {
+    size: 'md',
+    fluid: true,
+    skeleton: false,
+    readonly: false,
+    saved: action('saved'),
+    canceled: action('canceled'),
+    avatarChanged: action('avatarChanged'),
+    passwordChanged: action('passwordChanged'),
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    readonly: {
+      control: 'boolean',
+    },
+    skeleton: {
+      control: 'boolean',
+    },
+    fluid: {
+      control: 'boolean',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<UserProfileComponent>;
+
+export const Padrao: Story = {
+  name: 'Padrão',
+  render: args => ({
+    props: args,
+  }),
+};
+
+export const Skeleton: Story = {
+  args: {
+    skeleton: true,
+  },
+};
+
+export const SomenteLeitura: Story = {
+  name: 'Somente leitura',
+  args: {
+    readonly: true,
+  },
+};
+
+export const ErroApi: Story = {
+  name: 'Erro de API',
+  decorators: [
+    moduleMetadata({
+      providers: [{ provide: UserProfileService, useClass: ErrorUserProfileService }],
+    }),
+  ],
+};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add a standalone UserProfile component with accessible layout, keyboard shortcuts, and reactive forms for personal data, preferences, avatar, and password flows
- include an inline UserProfileService stub with simulated latency and feedback handling for profile, avatar, and password updates
- implement Carbon-aligned SCSS styling, skeleton states, and Storybook stories with controls and error/mobile scenarios

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5075fcbec8331b3c5e8ba45d377ed