### PR TITLE
feat: add read-only profile page

### DIFF
--- a/frontend/agentes-frontend/src/app/app.routes.ts
+++ b/frontend/agentes-frontend/src/app/app.routes.ts
@@ -23,6 +23,13 @@ export const routes: Routes = [
     data: { roles: ['AGENTE'] }
   },
   {
+    path: 'perfil',
+    loadComponent: () =>
+      import('./components/perfil/perfil.component').then(m => m.PerfilComponent),
+    canActivate: [AuthGuard, RoleGuard],
+    data: { roles: ['CORREGEDORIA', 'COMARCA', 'AGENTE'], title: 'Meu Perfil', icon: 'fas fa-user', showBack: false }
+  },
+  {
     path: 'carteirinha-agentes',
     loadComponent: () =>
       import('./components/carteirinha-agentes/carteirinha-agentes.component').then(m => m.CarteirinhaAgentesComponent),

--- a/frontend/agentes-frontend/src/app/components/header/header.component.html
+++ b/frontend/agentes-frontend/src/app/components/header/header.component.html
@@ -48,7 +48,11 @@
       </span>
     </a>
     <ul class="dropdown-menu dropdown-menu-end">
-      <li><a class="dropdown-item" href="#"><i class="fas fa-user me-2"></i>Perfil</a></li>
+      <li>
+        <a class="dropdown-item" routerLink="/perfil">
+          <i class="fas fa-user me-2"></i>Meu perfil
+        </a>
+      </li>
       <li><hr class="dropdown-divider"></li>
       <li>
         <a class="dropdown-item" href="#" (click)="logout()">

--- a/frontend/agentes-frontend/src/app/components/perfil/perfil.component.html
+++ b/frontend/agentes-frontend/src/app/components/perfil/perfil.component.html
@@ -1,0 +1,89 @@
+<div class="perfil-page container py-4">
+  <div class="page-surface">
+    <header class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-4">
+      <div>
+        <h1 class="page-title mb-1">Meu perfil</h1>
+        <p class="text-muted mb-0">Visualize com segurança as informações cadastradas no sistema.</p>
+      </div>
+      <span class="badge rounded-pill perfil-badge" *ngIf="usuario">
+        <i class="fas fa-shield-alt me-2"></i>
+        {{ perfil || 'Perfil não identificado' }}
+      </span>
+    </header>
+
+    <section *ngIf="loading" class="text-center py-5" aria-live="polite">
+      <div class="spinner-border" role="status" aria-hidden="true"></div>
+      <p class="text-muted mt-3 mb-0">Carregando informações do perfil…</p>
+    </section>
+
+    <ng-container *ngIf="!loading">
+      <div *ngIf="erro" class="alert alert-{{ erroTipo }} d-flex align-items-center" role="alert">
+        <i class="fas fa-circle-info me-2"></i>
+        <span>{{ erro }}</span>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <i class="fas fa-id-card me-2"></i>
+          Dados básicos
+        </div>
+        <div class="card-body">
+          <div class="row g-4">
+            <div class="col-12 col-md-6">
+              <span class="info-label">Nome completo</span>
+              <p class="info-value mb-0">{{ nome }}</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">E-mail</span>
+              <p class="info-value mb-0">{{ email }}</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">CPF</span>
+              <p class="info-value mb-0">{{ cpf }}</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">Telefone</span>
+              <p class="info-value mb-0">{{ telefone }}</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">Status do cadastro</span>
+              <p class="info-value mb-0">
+                <span class="badge text-uppercase badge-status" [ngClass]="statusBadgeClass()">{{ status }}</span>
+              </p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">Data de cadastro</span>
+              <p class="info-value mb-0">{{ dataCadastro }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <i class="fas fa-clipboard-list me-2"></i>
+          Informações complementares
+        </div>
+        <div class="card-body">
+          <div class="row g-4">
+            <div class="col-12 col-md-6">
+              <span class="info-label">Disponibilidade informada</span>
+              <p class="info-value mb-0">{{ disponibilidade }}</p>
+            </div>
+            <div class="col-12 col-md-6">
+              <span class="info-label">Comarcas vinculadas</span>
+              <p class="info-value mb-0">{{ comarcas }}</p>
+            </div>
+            <div class="col-12">
+              <span class="info-label">Áreas de atuação</span>
+              <p class="info-value mb-0">{{ areasAtuacao }}</p>
+            </div>
+          </div>
+          <p class="text-muted mt-4 mb-0" *ngIf="!agente">
+            Informações detalhadas são exibidas quando há um cadastro de agente associado ao usuário.
+          </p>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+</div>

--- a/frontend/agentes-frontend/src/app/components/perfil/perfil.component.scss
+++ b/frontend/agentes-frontend/src/app/components/perfil/perfil.component.scss
@@ -1,0 +1,66 @@
+@use '../../shared/general/colors/colors' as colors;
+
+.perfil-page {
+  .page-surface {
+    border-radius: 1.25rem;
+  }
+
+  .page-title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: colors.$neutral-800;
+  }
+
+  .perfil-badge {
+    background-color: rgba(colors.$red-800, 0.1);
+    color: colors.$red-800;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+  }
+
+  .info-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    color: colors.$neutral-500;
+  }
+
+  .info-value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: colors.$neutral-800;
+  }
+
+  .badge-status {
+    padding: 0.45rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .card {
+    border-radius: 1rem;
+    overflow: hidden;
+  }
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+  }
+
+  .spinner-border {
+    color: colors.$red-700;
+  }
+
+  @media (max-width: 768px) {
+    .page-surface {
+      padding: 1rem;
+    }
+
+    .page-title {
+      font-size: 1.5rem;
+    }
+  }
+}

--- a/frontend/agentes-frontend/src/app/components/perfil/perfil.component.ts
+++ b/frontend/agentes-frontend/src/app/components/perfil/perfil.component.ts
@@ -1,0 +1,180 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ApiService } from '../../services/api.service';
+import { AuthService } from '../../services/auth.service';
+import { AgenteVoluntarioResponseDTO, Usuario } from '../../models/interfaces';
+
+@Component({
+  selector: 'app-perfil',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './perfil.component.html',
+  styleUrls: ['./perfil.component.scss']
+})
+export class PerfilComponent implements OnInit {
+  loading = true;
+  erro = '';
+  erroTipo: 'warning' | 'danger' | 'info' = 'warning';
+
+  usuario?: Usuario | null;
+  agente?: AgenteVoluntarioResponseDTO;
+
+  constructor(
+    private readonly api: ApiService,
+    private readonly auth: AuthService
+  ) {}
+
+  ngOnInit(): void {
+    this.usuario = this.auth.getCurrentUser();
+    if (!this.usuario) {
+      this.loading = false;
+      this.erro = 'Nenhum usuário autenticado foi identificado.';
+      this.erroTipo = 'danger';
+      return;
+    }
+
+    this.carregarPerfil();
+  }
+
+  get nome(): string {
+    return this.agente?.nomeCompleto || this.usuario?.nome || '—';
+  }
+
+  get email(): string {
+    return this.usuario?.email || this.agente?.email || '—';
+  }
+
+  get perfil(): string {
+    return this.usuario?.perfil || '—';
+  }
+
+  get cpf(): string {
+    return this.formatarCPF(this.agente?.cpf);
+  }
+
+  get telefone(): string {
+    return this.formatarTelefone(this.agente?.telefone);
+  }
+
+  get disponibilidade(): string {
+    return this.agente?.disponibilidade || '—';
+  }
+
+  get status(): string {
+    return this.agente?.status || '—';
+  }
+
+  get dataCadastro(): string {
+    if (!this.agente?.dataCadastro) {
+      return '—';
+    }
+
+    try {
+      return new Intl.DateTimeFormat('pt-BR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      }).format(new Date(this.agente.dataCadastro));
+    } catch (error) {
+      console.warn('Não foi possível formatar dataCadastro do perfil.', error);
+      return '—';
+    }
+  }
+
+  get comarcas(): string {
+    const lista = this.agente?.comarcas || [];
+    if (!lista?.length) {
+      return '—';
+    }
+
+    return lista
+      .map(comarca => (comarca as any)?.nomeComarca || '')
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  get areasAtuacao(): string {
+    const lista = this.agente?.areasAtuacao || [];
+    if (!lista?.length) {
+      return '—';
+    }
+
+    return lista
+      .map(area => (area as any)?.nomeAreaAtuacao || '')
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  statusBadgeClass(): string {
+    const status = (this.status || '').toUpperCase();
+    switch (status) {
+      case 'ATIVO':
+        return 'bg-success';
+      case 'INATIVO':
+        return 'bg-danger';
+      case 'EM_ANALISE':
+        return 'bg-warning text-dark';
+      case 'QUADRO_RESERVA':
+        return 'bg-info';
+      default:
+        return 'bg-secondary';
+    }
+  }
+
+  private carregarPerfil(): void {
+    this.loading = true;
+    this.api.buscarAgenteMe().subscribe({
+      next: perfil => {
+        this.agente = perfil;
+        this.loading = false;
+        this.erro = '';
+      },
+      error: (error: HttpErrorResponse) => {
+        this.loading = false;
+        const status = error.status;
+        if (status === 403) {
+          this.erro = 'As informações detalhadas do agente não estão disponíveis para o seu perfil.';
+          this.erroTipo = 'info';
+        } else if (status === 404) {
+          this.erro = 'Não encontramos um cadastro de agente associado ao seu usuário.';
+          this.erroTipo = 'warning';
+        } else {
+          this.erro = 'Não foi possível carregar as informações completas do perfil no momento.';
+          this.erroTipo = 'danger';
+        }
+      }
+    });
+  }
+
+  private formatarCPF(cpf?: string): string {
+    if (!cpf) {
+      return '—';
+    }
+
+    const digits = cpf.replace(/\D/g, '');
+    if (digits.length !== 11) {
+      return cpf;
+    }
+
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+
+  private formatarTelefone(telefone?: string): string {
+    if (!telefone) {
+      return '—';
+    }
+
+    const digits = telefone.replace(/\D/g, '');
+    if (digits.length === 10) {
+      return digits.replace(/(\d{2})(\d{4})(\d{4})/, '($1) $2-$3');
+    }
+    if (digits.length === 11) {
+      return digits.replace(/(\d{2})(\d{5})(\d{4})/, '($1) $2-$3');
+    }
+
+    return telefone;
+  }
+}

--- a/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.ts
+++ b/frontend/agentes-frontend/src/app/components/sidebar/sidebar.component.ts
@@ -27,6 +27,7 @@ export class SidebarComponent implements OnInit {
   isLoggedIn = false;
   private readonly menuItems: MenuItem[] = [
     { label: 'Dashboard', icon: 'fas fa-tachometer-alt', link: '/', roles: ['CORREGEDORIA', 'COMARCA', 'AGENTE'], exact: true },
+    { label: 'Meu Perfil', icon: 'fas fa-user', link: '/perfil', roles: ['CORREGEDORIA', 'COMARCA', 'AGENTE'] },
     { label: 'Carteirinha', icon: 'fas fa-id-badge', link: '/carteirinha', roles: ['AGENTE'] },
     { label: 'Agentes Voluntários', icon: 'fas fa-users', link: '/agentes', roles: ['CORREGEDORIA', 'COMARCA'] },
     { label: 'Impressão Carteirinhas', icon: 'fas fa-id-badge', link: '/carteirinha-agentes', roles: ['CORREGEDORIA'] },
@@ -56,6 +57,7 @@ export class SidebarComponent implements OnInit {
     if (this.permissionService.hasAnyRole(['CORREGEDORIA', 'COMARCA'])) {
       const weight: Record<string, number> = {
         '/': 10,
+        '/perfil': 15,
         '/agentes': 20,
         '/agentes/cadastro': 30,
         '/credenciais': 40,


### PR DESCRIPTION
## Summary
- add a standalone read-only profile page that consumes the existing API and formats agent data
- update application routing, header dropdown, and sidebar menu to link to the new profile experience
- style the profile view with the design system colors and typography for consistency

## Testing
- npm run build *(fails: Cannot find module '@zxing/browser')*

------
https://chatgpt.com/codex/tasks/task_e_68e5149e199c833184c17022dba5014b